### PR TITLE
Remove pymilvus-orm bypass

### DIFF
--- a/src/components/menu/index.jsx
+++ b/src/components/menu/index.jsx
@@ -64,14 +64,6 @@ const Menu = props => {
     const thirdLevelMenuNames = [];
     // filter all compatible api menu items(not a directory)
     const filteredMenus = apiMenus.reduce((prev, menu) => {
-      //? vvvvvv Code below should be removed when publish.
-      //? Here just for show pymilvus-orm & node left menu when doc version is 'v1.1.0'
-      if (
-        menu?.category === 'pymilvus-orm' &&
-        menu?.apiVersion === 'v2.0.alpha'
-      )
-        menu.docVersion = formatVersion;
-      //? ^^^^^^
       if (menu?.isMenu && !menu?.label2) {
         menu?.id === 'api_reference'
           ? rootMenu.push(menu)
@@ -96,6 +88,7 @@ const Menu = props => {
 
   /**
    * Replace api reference menu in MenuList with allApiMenus.
+   * Will append allApiMenus to the end if there's no api reference menu.
    * @param {array} menus MenuList.
    * @param {array} apiMenus allApiMenus.
    * @returns {array} Combined array with MenuList(without api reference) and allApiMenus.
@@ -103,6 +96,12 @@ const Menu = props => {
   const mergeMenus = (menus=[], apiMenus=[]) => {
     const apiMenu = apiMenus[0];
     if (!apiMenu) return menus;
+    // If menus doesn't have "API" menu, add apiMenu as the last one.
+    if (!menus.find(item => item?.id === "API")) {
+      apiMenu.order = menus.length;
+      return [...menus, apiMenu];
+    }
+    // If exists, replace "API" with apiMenu.
     return menus.reduce((prev, item) => {
       const {id, order} = item;
       if (id === "API") {

--- a/walkFile.js
+++ b/walkFile.js
@@ -57,7 +57,9 @@ const handleCfgFile = (fileObj, { dirPath, filePath, isVariables }) => {
       `v${content?.milvus_go_sdk_version}`;
     const java = content?.milvus_java_sdk_version &&
     `v${content?.milvus_java_sdk_version}`;
-    result = { pymilvus, go, java };
+    const orm = content?.milvus_python_orm_sdk_version &&
+    `v${content?.milvus_python_orm_sdk_version}`;
+    result = { pymilvus, go, java, 'pymilvus-orm': orm };
   }
   fileObj[parent] = fileObj[parent]
     ? { ...fileObj[parent], ...result }


### PR DESCRIPTION
Pymilvus-orm can correctly show when version is preview:
![image](https://user-images.githubusercontent.com/83751452/123196303-41658d00-d4dc-11eb-8fe1-b7df65c9b051.png)

```
{
  preview: {
    pymilvus: 'v1.1.0',
    go: 'v1.1.0',
    java: 'v1.1.0',
    'pymilvus-orm': 'v2.0.alpha',
    version: 'v2.0.0',
    released: 'no'
  },
  'v0.10.0': { version: 'v0.10.0', released: 'no' },
  'v0.10.1': { version: 'v0.10.1', released: 'no' },
  'v0.10.2': { version: 'v0.10.2', released: 'no' },
  'v0.10.3': { version: 'v0.10.3', released: 'no' },
  'v0.10.4': { version: 'v0.10.4', released: 'no' },
  'v0.10.5': { version: 'v0.10.5', released: 'no' },
  'v0.10.6': { version: 'v0.10.6', released: 'no' },
  'v0.11.0': { version: 'v0.11.0', released: 'no' },
  'v0.6.0': { version: 'v0.6.0', released: 'no' },
  'v0.7.0': { version: 'v0.7.0', released: 'no' },
  'v0.7.1': { version: 'v0.7.1', released: 'no' },
  'v0.8.0': { version: 'v0.8.0', released: 'no' },
  'v0.8.1': { version: 'v0.8.1', released: 'no' },
  'v0.9.0': { version: 'v0.9.0', released: 'no' },
  'v0.9.1': { version: 'v0.9.1', released: 'no' },
  'v0.x': { version: 'v0.x', released: 'yes' },
  'v1.0.0': {
    pymilvus: 'v1.0.1',
    go: 'v1.0.0',
    java: 'v1.0.0',
    'pymilvus-orm': undefined,
    version: 'v1.0.0',
    released: 'yes'
  },
  'v1.1.0': {
    pymilvus: 'v1.1.0',
    go: 'v1.1.0',
    java: 'v1.1.0',
    'pymilvus-orm': undefined,
    version: 'v1.1.0',
    released: 'yes'
  },
  'v1.1.1': {
    pymilvus: 'v1.1.2',
    go: 'v1.1.0',
    java: 'v1.1.0',
    'pymilvus-orm': undefined,
    version: 'v1.1.1',
    released: 'yes'
  },
  master: { version: 'v2.0.0', released: 'no' }
}
```