### PR TITLE
Refine api doc version

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -49,6 +49,7 @@ const newestVersion = getNewestVersion(versionInfo);
 const versions = [];
 
 versionInfo.preview = {
+  ...versionInfo.preview,
   version: 'preview',
   released: 'no',
 };

--- a/gatsbyUtils/createPages.js
+++ b/gatsbyUtils/createPages.js
@@ -784,7 +784,6 @@ const generateApiMenus = nodes => {
   };
   return nodes.reduce(
     (prev, item) => {
-      // docVersion may be empty string
       const {
         name,
         category,

--- a/gatsbyUtils/sourceNodes.js
+++ b/gatsbyUtils/sourceNodes.js
@@ -3,16 +3,16 @@ const HTMLParser = require('node-html-parser');
 const path = require('path');
 
 /**
- * use api version to find target doc version
- * @param {object} info version info from walkFile output
- * @param {string} category category name, such as pymilvus, java-sdk
- * @param {string} apiVersion current api version
- * @returns {string} target doc version, will return empty string if no match
+ * Use api version to find target doc versions.
+ * @param {object} info Version info from walkFile output.
+ * @param {string} category category name, such as pymilvus, java-sdk.
+ * @param {string} apiVersion Current api version.
+ * @returns {array} Target doc versions, will return empty array if no match.
  */
 const findDocVersion = (info, category, apiVersion) =>
   Object.keys(info)
     .reverse()
-    .find(i => info[i] && info[i][category] === apiVersion) || '';
+    .filter(i => info[i] && info[i][category] === apiVersion);
 
 /**
  * Find and get the path of all files under the dirPath.

--- a/src/components/menu/index.jsx
+++ b/src/components/menu/index.jsx
@@ -68,7 +68,7 @@ const Menu = props => {
         menu?.id === 'api_reference'
           ? rootMenu.push(menu)
           : secondLevelMenus.push(menu);
-      } else if (menu?.docVersion === currentDocVersion) {
+      } else if (menu?.docVersion?.includes(currentDocVersion)) {
         prev.push(menu);
         thirdLevelMenuNames.push(menu?.label2);
       }
@@ -78,7 +78,7 @@ const Menu = props => {
     const filteredSecondLevelMenus = secondLevelMenus.filter(
       v =>
         thirdLevelMenuNames.includes(v?.id) &&
-        v?.docVersion === currentDocVersion
+        v?.docVersion?.includes(currentDocVersion)
     );
     // merge the level 1&2 menus into results
     filteredMenus?.length &&

--- a/src/templates/apiDocTemplate.js
+++ b/src/templates/apiDocTemplate.js
@@ -26,15 +26,24 @@ export default function Template({ data, pageContext }) {
     languages: ['java', 'go', 'python', 'javascript'],
   };
 
+  // Get docVersion from local stroage, to keep the doc verison consistent.
+  const localStorageDocVer = window.localStorage.getItem('docVersion');
+  // To judge if docVersion includes local storage doc verion or not.
+  // Reset to the latest doc version if not including.
+  const targetDocVersion =
+    (docVersion.includes(localStorageDocVer)
+      ? localStorageDocVer
+      : docVersion[0]) || 'master';
+
   useCodeCopy(locale, hljsCfg);
-  useAlgolia(locale, docVersion);
+  useAlgolia(locale, targetDocVersion);
 
   const layout = data.allFile.edges[0]
     ? data.allFile.edges[0].node.childI18N.layout
     : {};
 
   const menuList = allMenus.find(
-    v => v.absolutePath.includes(docVersion) && v.lang === locale
+    v => v.absolutePath.includes(targetDocVersion) && v.lang === locale
   );
 
   const nav = {
@@ -50,7 +59,7 @@ export default function Template({ data, pageContext }) {
         nav={nav}
         current="doc"
         menuList={menuList}
-        version={docVersion || 'master'}
+        version={targetDocVersion}
         headings={[]}
         versions={docVersions}
         newestVersion={newestVersion}

--- a/src/templates/apiDocTemplate.js
+++ b/src/templates/apiDocTemplate.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Seo from '../components/seo';
 import Layout from '../components/docLayout';
 import { graphql } from 'gatsby';
@@ -20,20 +20,26 @@ export default function Template({ data, pageContext }) {
     newestVersion,
   } = pageContext;
 
+  const [targetDocVersion, setTargetDocVersion] = useState('master');
+
   // https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md
   // Specify supported languages to fix Java doc code layout.
   const hljsCfg = {
     languages: ['java', 'go', 'python', 'javascript'],
   };
 
-  // Get docVersion from local stroage, to keep the doc verison consistent.
-  const localStorageDocVer = window.localStorage.getItem('docVersion');
-  // To judge if docVersion includes local storage doc verion or not.
-  // Reset to the latest doc version if not including.
-  const targetDocVersion =
-    (docVersion.includes(localStorageDocVer)
-      ? localStorageDocVer
-      : docVersion[0]) || 'master';
+  useEffect(() => {
+    // Get docVersion from local stroage, to keep the doc verison consistent.
+    const localStorageDocVer = window?.localStorage?.getItem('docVersion');
+    // To judge if docVersion includes local storage doc verion or not.
+    // Reset to the latest doc version if not including.
+    const ver =
+      (docVersion.includes(localStorageDocVer)
+        ? localStorageDocVer
+        : docVersion[0]) || 'master';
+    setTargetDocVersion(ver);
+    window?.localStorage?.setItem('docVersion', ver);
+  }, [docVersion]);
 
   useCodeCopy(locale, hljsCfg);
   useAlgolia(locale, targetDocVersion);

--- a/src/templates/docTemplate.js
+++ b/src/templates/docTemplate.js
@@ -36,6 +36,10 @@ export default function Template({
   } = pageContext;
   versions = versions.sort(sortVersions);
 
+  useEffect(() => {
+    window.localStorage.setItem('docVersion', version);
+  }, [version]);
+
   const { isMobile } = useMobileScreen();
 
   const [showBack, setShowBack] = useState(false);

--- a/src/templates/docTemplate.js
+++ b/src/templates/docTemplate.js
@@ -37,7 +37,7 @@ export default function Template({
   versions = versions.sort(sortVersions);
 
   useEffect(() => {
-    window.localStorage.setItem('docVersion', version);
+    window?.localStorage?.setItem('docVersion', version);
   }, [version]);
 
   const { isMobile } = useMobileScreen();


### PR DESCRIPTION
Issue: One api reference corresponds to a few of doc versions.
Solution: Use window.localStorage.docVersion to pass origin doc version.