### PR TITLE
Reduce old doc pages and add i18n api reference title

### DIFF
--- a/gatsbyUtils/createPages.js
+++ b/gatsbyUtils/createPages.js
@@ -427,8 +427,20 @@ const generateHomeData = edges => {
  */
 const filterMdWithVersion = edges => {
   return edges.filter(({ node: { fileAbsolutePath, frontmatter } }) => {
+    /**
+     * Filter correct md file by version.
+     * Drop md file with no version or older than v1.0.0 (except v0.x).
+     * @param {string} path File absolute path.
+     * @returns {boolean} If this md should be dropped or not.
+     */
+    const filterVersion = path => {
+      const mdVersion = findVersion(path);
+      if (mdVersion?.startsWith('v0.') && !mdVersion?.startsWith('v0.x'))
+        return false;
+      return !!mdVersion;
+    };
     return (
-      (!!findVersion(fileAbsolutePath) ||
+      (filterVersion(fileAbsolutePath) ||
         fileAbsolutePath.includes('/docs/versions/master/common') ||
         fileAbsolutePath.includes('/blog/zh-CN') ||
         (fileAbsolutePath.includes('/docs/versions/master/preview/') &&

--- a/gatsbyUtils/createPages.js
+++ b/gatsbyUtils/createPages.js
@@ -854,6 +854,9 @@ const generateApiMenus = nodes => {
         order: -1,
         isMenu: true,
         outLink: null,
+        i18n: {
+          title: { en: 'API Reference', cn: 'API 参考' },
+        },
       },
     ]
   );

--- a/src/components/menu/index.jsx
+++ b/src/components/menu/index.jsx
@@ -161,6 +161,12 @@ const Menu = props => {
         });
 
         topMenu.forEach(v => {
+          // i18n: { title: { en: 'API Reference', cn: 'API 参考' }, }
+          if (v?.i18n) {
+            const { i18n, title } = v;
+            const localizedTitle = i18n?.title?.[locale] || title;
+            localizedTitle && (v.title = localizedTitle);
+          }
           const item = {
             ...v,
             children: [],


### PR DESCRIPTION
## Summary:

- Reduce 732MB (before is 1.42GB and now is 688MB) of docker image size.
- Add cn title for api reference menu.

## Before:
![image](https://user-images.githubusercontent.com/83751452/123752454-5fbbf600-d8eb-11eb-9a23-b60ad25e7fe9.png)
![image](https://user-images.githubusercontent.com/83751452/123752914-e07af200-d8eb-11eb-9a77-3989953c1c98.png)


## After:
![image](https://user-images.githubusercontent.com/83751452/123752531-74988980-d8eb-11eb-979c-0da336f3df25.png)
![image](https://user-images.githubusercontent.com/83751452/123752717-a9a4dc00-d8eb-11eb-95e3-155659db2287.png)
