### PR TITLE
move old doc pages to v0.x

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -15,6 +15,9 @@ server {
 
     # rewrites
 
+    rewrite ^/docs/v0\.\d+.* /docs/v0.x/overview.md permanent;
+    rewrite ^/cn/docs/v0\.\d+.* /cn/docs/v0.x/overview.md permanent;
+
     rewrite ^/cn/docs/guides/get_started/install_milvus/(.*).md$ /cn/docs/$1.md permanent;
     rewrite ^/cn/docs/guides/(.*).md$ /cn/docs/$1.md permanent;
     rewrite ^/cn/docs/reference/(.*).md$ /cn/docs/$1.md permanent;


### PR DESCRIPTION
Request to `/docs/v0.[0-9].*` will be moved to `/docs/v0.x/overview.md` permanently.