### PR TITLE
fix text type code color

### DIFF
--- a/src/templates/docTemplate.less
+++ b/src/templates/docTemplate.less
@@ -127,10 +127,6 @@
     display: inline-block;
   }
 
-  .language-text {
-    color: #fff;
-  }
-
   audio:not([controls]) {
     display: none;
     height: 0;


### PR DESCRIPTION
page url: [Install Milvus Standalone](https://milvus.io/docs/install_standalone-docker.md)

before:
<img width="635" alt="before" src="https://user-images.githubusercontent.com/20420181/124101018-8b78e080-da91-11eb-87e0-ce2163746b97.png">

after:
<img width="621" alt="after" src="https://user-images.githubusercontent.com/20420181/124101049-90d62b00-da91-11eb-9b87-98c9f209a36f.png">
