### PR TITLE
social share buttons can go down with scrolling now

### DIFF
--- a/src/templates/blogTemplate.jsx
+++ b/src/templates/blogTemplate.jsx
@@ -86,9 +86,8 @@ export default function Template({ data, pageContext }) {
           onClick={handleTagClick}
         />
 
-        <section className={`${styles.desc} col-8`}>
+        <section className={`${styles.desctop} col-8`}>
           <span className={styles.line}></span>
-          <span>{desc}</span>
           <Share
             url={shareUrl}
             quote={title}
@@ -97,6 +96,11 @@ export default function Template({ data, pageContext }) {
             wrapperClass={styles.share}
             vertical={true}
           />
+        </section>
+
+        <section className={`${styles.desc} col-8`}>
+          <span className={styles.line}></span>
+          <span>{desc}</span>
         </section>
 
         <div

--- a/src/templates/blogTemplate.module.less
+++ b/src/templates/blogTemplate.module.less
@@ -63,6 +63,26 @@
     }
   }
 
+
+  .desctop{
+    position: relative;
+    margin: 0 auto 55px auto;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 125px;
+    text-align: left;
+    padding-left: 20px;
+    .share {
+      position: absolute;
+      right: -20%;
+      top: 0px;
+      .hover;
+
+      @media @tablet, @phone {
+        display: none;
+      }
+    }
+  }
   .desc {
     position: relative;
     margin: 0 auto 55px auto;
@@ -84,7 +104,7 @@
     .share {
       position: absolute;
       right: -20%;
-      top: 0;
+      top: 0px;
       .hover;
 
       @media @tablet, @phone {


### PR DESCRIPTION
In order to make the social share icons group stick on top right of the screen when scrolling down the page, we need CSS `position: sticky`.