### PR TITLE
Sticky share button: fix the format in CSS

### DIFF
--- a/src/templates/blogTemplate.jsx
+++ b/src/templates/blogTemplate.jsx
@@ -86,8 +86,7 @@ export default function Template({ data, pageContext }) {
           onClick={handleTagClick}
         />
 
-        <section className={`${styles.desctop} col-8`}>
-          <span className={styles.line}></span>
+        <section className={`${styles.shareContainer} col-8`}>
           <Share
             url={shareUrl}
             quote={title}

--- a/src/templates/blogTemplate.module.less
+++ b/src/templates/blogTemplate.module.less
@@ -64,7 +64,7 @@
   }
 
 
-  .desctop{
+  .shareContainer {
     position: relative;
     margin: 0 auto 55px auto;
     position: -webkit-sticky;
@@ -75,7 +75,7 @@
     .share {
       position: absolute;
       right: -20%;
-      top: 0px;
+      top: 0;
       .hover;
 
       @media @tablet, @phone {


### PR DESCRIPTION
I renamed the Share button container(desctop -> shareContainer) and fixed the format in CSS (0px -> 0)