### PR TITLE
chore: temporarily hide Slack entry points across the site

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -14,7 +14,6 @@ import {
   GITHUB_VTS_LINK,
   GITHUB_DEEP_SEARCHER_LINK,
   GITHUB_CLAUDE_CONTEXT_LINK,
-  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import { RightTopArrowIcon } from '@/components/icons';
 import { SocialMedias, SocialMediasCN } from '../socialMedias';
@@ -137,12 +136,12 @@ const Footer = (props: Props) => {
           to: MILVUS_OFFICE_HOURS_URL,
           isExternal: true,
         },
-        {
-          id: 'community-2',
-          name: t('header:community.slack'),
-          to: MILVUS_SLACK_LINK,
-          isExternal: true,
-        },
+        // {
+        //   id: 'community-2',
+        //   name: t('header:community.slack'),
+        //   to: MILVUS_SLACK_LINK,
+        //   isExternal: true,
+        // },
         {
           id: 'community-3',
           name: 'Discord',

--- a/src/components/header/DescktopHeader.tsx
+++ b/src/components/header/DescktopHeader.tsx
@@ -19,7 +19,6 @@ import {
   DISCORD_INVITE_URL,
   GITHUB_MILVUS_COMMUNITY_LINK,
   GITHUB_CLAUDE_CONTEXT_LINK,
-  MILVUS_SLACK_LINK
 } from '@/consts/links';
 import { MILVUS_OFFICE_HOURS_URL } from '@/consts/externalLinks';
 import { LanguageSelector } from '@/components/language-selector';
@@ -132,11 +131,11 @@ export default function DesktopHeader(props: Props) {
           link: MILVUS_OFFICE_HOURS_URL,
           rel: 'noopener noreferrer',
         },
-        {
-          label: t("community.slack"),
-          link: MILVUS_SLACK_LINK,
-          rel: 'noopener noreferrer',
-        },
+        // {
+        //   label: t("community.slack"),
+        //   link: MILVUS_SLACK_LINK,
+        //   rel: 'noopener noreferrer',
+        // },
         {
           label: t('community.discord'),
           link: DISCORD_INVITE_URL,

--- a/src/components/header/mobileHeader.tsx
+++ b/src/components/header/mobileHeader.tsx
@@ -25,7 +25,6 @@ import {
   DISCORD_INVITE_URL,
   GITHUB_MILVUS_COMMUNITY_LINK,
   GITHUB_CLAUDE_CONTEXT_LINK,
-  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import { MILVUS_OFFICE_HOURS_URL } from '@/consts/externalLinks';
 import { RightTopArrowIcon } from '../icons';
@@ -289,7 +288,7 @@ export default function MobileHeader(props: {
                       {t('community.officeHours')}
                       <RightTopArrowIcon />
                     </a>
-                    <a
+                    {/* <a
                       href={MILVUS_SLACK_LINK}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -297,7 +296,7 @@ export default function MobileHeader(props: {
                     >
                       {t('community.slack')}
                       <RightTopArrowIcon />
-                    </a>
+                    </a> */}
                     <a
                       href={DISCORD_INVITE_URL}
                       target="_blank"

--- a/src/components/socialMedias/index.tsx
+++ b/src/components/socialMedias/index.tsx
@@ -5,7 +5,6 @@ import {
   MILVUS_YOUTUBE_CHANNEL_LINK,
   MILVUS_LINKEDIN_URL,
   MILVUS_BILIBILI_LINK,
-  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import clsx from 'clsx';
 import Popper, { PopperPlacementType } from '@mui/material/Popper';
@@ -20,7 +19,6 @@ import {
   MediaWechat,
   MediaBilibili,
   MediaGit,
-  MediaSlack
 } from '@/components/icons';
 import { useRef, useState } from 'react';
 
@@ -31,7 +29,7 @@ const socialJson = [
     link: GITHUB_MILVUS_LINK,
   },
   { icon: <MediaX />, name: 'X', link: MILVUS_TWITTER_LINK },
-  { icon: <MediaSlack />, name: 'Slack', link: MILVUS_SLACK_LINK },
+  // { icon: <MediaSlack />, name: 'Slack', link: MILVUS_SLACK_LINK },
   {
     icon: <MediaDiscord />,
     name: 'Discord',

--- a/src/parts/community/Community.tsx
+++ b/src/parts/community/Community.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Layout from '@/components/layout/commonLayout';
 import { useTranslation } from 'react-i18next';
-import { DISCORD_INVITE_URL, MILVUS_BILIBILI_LINK, MILVUS_SLACK_LINK } from '@/consts';
+import { DISCORD_INVITE_URL, MILVUS_BILIBILI_LINK } from '@/consts';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import classes from '@/styles/community.module.css';
 import pageClasses from '@/styles/responsive.module.css';
@@ -44,13 +44,13 @@ export const Community: FC<Props> = (props: Props) => {
       catLabel: t('join'),
       show: true,
     },
-    {
-      label: 'Slack',
-      imgUrl: '/images/community/socialMedia/slack.svg',
-      href: MILVUS_SLACK_LINK,
-      catLabel: t('join'),
-      show: true,
-    },
+    // {
+    //   label: 'Slack',
+    //   imgUrl: '/images/community/socialMedia/slack.svg',
+    //   href: MILVUS_SLACK_LINK,
+    //   catLabel: t('join'),
+    //   show: true,
+    // },
     {
       label: 'Discord',
       imgUrl: '/images/community/socialMedia/discord.svg',


### PR DESCRIPTION
Comment out Slack links in header, mobile header, footer, social media icons, and community page.