### PR TITLE
fix(seo): fix blog canonical URLs and add nginx redirect rules for 404s

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -363,6 +363,14 @@ server {
     # 2025 Jan 14
     rewrite ^/blog/introducing-milvus-2-5.md /blog/introduce-milvus-2-5-full-text-search-powerful-metadata-filtering-and-more.md permanent;
 
+    # blog frontmatter id / filename mismatch redirects
+    rewrite ^/blog/2022-08-16-A-Quick-Guide-to-Benchmarking-Milvus-2-1\.md$ /blog/2022-08-16-Benchmark-Quick-Setup.md permanent;
+    rewrite ^/blog/ai-for-smarter-browsing-filtering-web-content-with-pixtral-milvus-browser-use\.md$ /blog/ai-for-smarter-browsing-filtering-web-content-with-pirxtral-milvus-browser-use.md permanent;
+    rewrite ^/blog/milvus-surpasses-20000-github-stars\.md$ /blog/milvus-surpasses-20000-GitHub-stars.md permanent;
+    rewrite ^/blog/Milvus-Data-Migration-Tool\.md$ /blog/2021-03-15-Milvus-Data-Migration-Tool.md permanent;
+    rewrite ^/blog/select-index-parameters-ivf-index\.md$ /blog/2020-02-26-select-index-parameters-ivf-index.md permanent;
+    rewrite ^/blog/how-milvus-26-upgrades-multilingual-full-text-search-at-scale\.md$ /blog/how-milvus-26-powers-hybrid-multilingual-search-at-scale.md permanent;
+
     # redirect old replicated links
     rewrite ^/docs/text_search_engine.md /docs/build-rag-with-milvus.md permanent;
     rewrite ^/docs/question_answering_system.md /docs/build-rag-with-milvus.md permanent;
@@ -394,6 +402,7 @@ server {
     rewrite ^/docs/v2.4.x/from-m2x.md https://github.com/zilliztech/vts permanent;
     rewrite ^/docs/integrate_with_phidata.md /docs/integrate_with_agno.md permanent;
     rewrite ^/docs/(zh-hant|zh|ja|jp|fr|ko|ru|de|es|pt|it|ar|id|cn)/(v2\.[0-3]\.x)(/.*)?$ /docs/$2 permanent;
+    rewrite ^/docs/(ar|id|ru|zh-hant)/(v2\.4\.x)(/.*)?$ /docs/$2$3 permanent;
     rewrite ^/docs/create-collection-instantly.md /docs/create-collection.md permanent;
     rewrite ^/docs/(zh-hant|zh|ja|jp|fr|ko|ru|de|es|pt|it|ar|id|cn)/create-collection-instantly.md /docs/$1/create-collection.md permanent;
 
@@ -423,7 +432,7 @@ server {
     # /v2.x.x/{Python categories}/... → pymilvus SDK
     rewrite ^/(v2\.\d+\.x)/(ORM|MilvusClient|DataImport|EmbeddingModels|Rerankers)(/.*)?$ /api-reference/pymilvus/$1/$2$3 permanent;
     # /v2.x.x/{Go categories}/... → Go SDK
-    rewrite ^/(v2\.\d+\.x)/(Management|Collections|Vector|Client|Authentication|Partitions|ResourceGroup|Database|Volume|Data|Index|Schema|SearchResult|User)(/.*)?$ /api-reference/go/$1/$2$3 permanent;
+    rewrite ^/(v2\.\d+\.x)/(Management|Collections|Vector|Client|Authentication|Partitions|ResourceGroup|Database|Volume|Data|Index|Schema|SearchResult|User|Connections|Alias)(/.*)?$ /api-reference/go/$1/$2$3 permanent;
 
     expires -1; # Set it to different value depending on your standard requirements
   }

--- a/src/components/localization/CreateBlogDetailProps.ts
+++ b/src/components/localization/CreateBlogDetailProps.ts
@@ -1,6 +1,7 @@
 import blogUtils from '@/utils/blog.utils';
 import { LanguageEnum } from '@/types/localization';
 import { markdownToHtml } from '@/utils/common';
+import { ABSOLUTE_BASE_URL } from '@/consts';
 
 export const createBlogDetailProps = (lang: LanguageEnum) => {
   const getBlogDetailStaticPaths = () => {
@@ -47,6 +48,15 @@ export const createBlogDetailProps = (lang: LanguageEnum) => {
       .filter(v => v.tags.some(tag => tags.includes(tag) && v.id !== id))
       .slice(0, 4);
 
+    // For non-English locales, derive canonical from the English blog:
+    // - If English blog has canonicalUrl (e.g., zilliz.com cross-post), use it
+    // - Otherwise, point to the English milvus.io blog URL
+    let canonicalUrl = (rest as Record<string, any>).canonicalUrl;
+    if (lang !== LanguageEnum.ENGLISH) {
+      const enBlog = enData.find(v => v.id === id) as Record<string, any> | undefined;
+      canonicalUrl = enBlog?.canonicalUrl || `${ABSOLUTE_BASE_URL}/blog/${id}`;
+    }
+
     return {
       props: {
         blogId: id,
@@ -60,6 +70,7 @@ export const createBlogDetailProps = (lang: LanguageEnum) => {
         ].slice(0, 4),
         tags,
         ...rest,
+        canonicalUrl,
       },
     };
   };


### PR DESCRIPTION
- Fix localized blog canonical: derive from English blog instead of self-referencing, resolving "Duplicate without user-selected canonical" for ~2300 localized blog pages
- Add 6 nginx rewrite rules for blog frontmatter id/filename mismatches
- Add nginx redirect for ar/id/ru/zh-hant v2.4.x docs to English
- Add Connections and Alias to Go SDK nginx redirect categories