### PR TITLE
feat: add docs v2.6.x pages

### DIFF
--- a/src/pages/docs/ar/v2.6.x/[id].tsx
+++ b/src/pages/docs/ar/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.ARABIC,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.ARABIC,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/ar/v2.6.x/index.tsx
+++ b/src/pages/docs/ar/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.ARABIC, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/de/v2.6.x/[id].tsx
+++ b/src/pages/docs/de/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.GERMAN,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.GERMAN,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/de/v2.6.x/index.tsx
+++ b/src/pages/docs/de/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.GERMAN, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/es/v2.6.x/[id].tsx
+++ b/src/pages/docs/es/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.SPANISH,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.SPANISH,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/es/v2.6.x/index.tsx
+++ b/src/pages/docs/es/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.SPANISH, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/fr/v2.6.x/[id].tsx
+++ b/src/pages/docs/fr/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.FRANCE,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.FRANCE,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/fr/v2.6.x/index.tsx
+++ b/src/pages/docs/fr/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.FRANCE, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/id/v2.6.x/[id].tsx
+++ b/src/pages/docs/id/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.INDONESIAN,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.INDONESIAN,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/id/v2.6.x/index.tsx
+++ b/src/pages/docs/id/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.INDONESIAN, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/it/v2.6.x/[id].tsx
+++ b/src/pages/docs/it/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.ITALIAN,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.ITALIAN,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/it/v2.6.x/index.tsx
+++ b/src/pages/docs/it/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.ITALIAN, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/ja/v2.6.x/[id].tsx
+++ b/src/pages/docs/ja/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.JAPANESE,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.JAPANESE,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/ja/v2.6.x/index.tsx
+++ b/src/pages/docs/ja/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.JAPANESE, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/ko/v2.6.x/[id].tsx
+++ b/src/pages/docs/ko/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.KOREAN,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.KOREAN,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/ko/v2.6.x/index.tsx
+++ b/src/pages/docs/ko/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.KOREAN, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/pt/v2.6.x/[id].tsx
+++ b/src/pages/docs/pt/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.PORTUGUESE,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.PORTUGUESE,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/pt/v2.6.x/index.tsx
+++ b/src/pages/docs/pt/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.PORTUGUESE, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/ru/v2.6.x/[id].tsx
+++ b/src/pages/docs/ru/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.RUSSIAN,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.RUSSIAN,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/ru/v2.6.x/index.tsx
+++ b/src/pages/docs/ru/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.RUSSIAN, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/v2.6.x/[id].tsx
+++ b/src/pages/docs/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.ENGLISH,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.ENGLISH,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/v2.6.x/index.tsx
+++ b/src/pages/docs/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.ENGLISH, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/zh-hant/v2.6.x/[id].tsx
+++ b/src/pages/docs/zh-hant/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.CHINESE_TW,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.CHINESE_TW,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/zh-hant/v2.6.x/index.tsx
+++ b/src/pages/docs/zh-hant/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.CHINESE_TW, 'v2.6.x');
+  return getPageStaticProps();
+};

--- a/src/pages/docs/zh/v2.6.x/[id].tsx
+++ b/src/pages/docs/zh/v2.6.x/[id].tsx
@@ -1,0 +1,22 @@
+import { GetStaticProps } from 'next';
+import { LanguageEnum } from '@/types/localization';
+import { DocDetailPage } from '@/components/localization/DocDetail';
+import { createDocDetailProps } from '@/components/localization/CreateDocDetailProps';
+
+export default DocDetailPage;
+
+export const getStaticPaths = () => {
+  const { getPageStaticPaths } = createDocDetailProps(
+    LanguageEnum.CHINESE,
+    'v2.6.x'
+  );
+  return getPageStaticPaths();
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { getPageStaticProps } = createDocDetailProps(
+    LanguageEnum.CHINESE,
+    'v2.6.x'
+  );
+  return getPageStaticProps(context);
+};

--- a/src/pages/docs/zh/v2.6.x/index.tsx
+++ b/src/pages/docs/zh/v2.6.x/index.tsx
@@ -1,0 +1,10 @@
+import { LanguageEnum } from '@/types/localization';
+import { createDocHomeProps } from '@/components/localization/CreateDocHomeProps';
+import { DocHomepage } from '@/components/localization/DocHome';
+
+export default DocHomepage;
+
+export const getStaticProps = async () => {
+  const getPageStaticProps = createDocHomeProps(LanguageEnum.CHINESE, 'v2.6.x');
+  return getPageStaticProps();
+};


### PR DESCRIPTION
## Summary
- Add v2.6.x docs routes across all locales (en, zh, zh-hant, ja, ko, ar, de, es, fr, id, it, pt, ru)
- Each locale gets `/docs/<locale>/v2.6.x/index.tsx` and `/docs/<locale>/v2.6.x/[id].tsx`

## Test plan
- [ ] Verify v2.6.x docs render for default and localized routes
- [ ] Confirm dynamic `[id]` pages resolve doc content correctly
- [ ] Check sitemap/canonical URLs include v2.6.x pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)