### PR TITLE
fix: improve docs lcp

### DIFF
--- a/src/components/LLMActions/index.tsx
+++ b/src/components/LLMActions/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, useEffect, ReactNode } from 'react';
-import { ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import classes from './index.module.css';
@@ -8,7 +7,7 @@ import { copyToCommand } from '@/utils/common';
 import { useGlobalLocale } from '@/hooks/use-global-locale';
 import { LanguageEnum } from '@/types/localization';
 import { useRouter } from 'next/router';
-import { ABSOLUTE_BASE_URL, MILVUS_RAW_DOCS_BASE_URL } from '@/consts';
+import { ABSOLUTE_BASE_URL } from '@/consts';
 
 enum PageAction {
   CopyPage = 'copy-page',
@@ -39,7 +38,12 @@ interface LLMActionsProps {
 export { PageAction };
 
 export default function LLMActions(props: LLMActionsProps) {
-  const { options, githubLink, classes: customClasses, mdContent: propsMdContent = '' } = props;
+  const {
+    options,
+    githubLink,
+    classes: customClasses,
+    mdContent: propsMdContent = '',
+  } = props;
   const { root = '' } = customClasses || {};
   const { t } = useTranslation('llm');
   const { locale } = useGlobalLocale();
@@ -71,10 +75,23 @@ export default function LLMActions(props: LLMActionsProps) {
 
   const handleCopyPage = async () => {
     try {
-      if (!mdContent) {
+      setCopyStatus('loading');
+      let content = mdContent;
+
+      if (!content && githubLink) {
+        const response = await fetch(githubLink);
+        if (!response.ok) {
+          throw new Error('Failed to fetch Markdown content');
+        }
+        content = await response.text();
+        setMdContent(content);
+      }
+
+      if (!content) {
         throw new Error('No Markdown content found');
       }
-      await copyToCommand(mdContent);
+
+      await copyToCommand(content);
       setCopyStatus('success');
       setTimeout(() => {
         setCopyStatus('idle');
@@ -146,15 +163,6 @@ export default function LLMActions(props: LLMActionsProps) {
     return <CopyIcon />;
   };
 
-  useEffect(() => {
-    if (githubLink) {
-      fetch(githubLink)
-        .then(response => response.text())
-        .then(data => setMdContent(data))
-        .catch(error => console.error('Error fetching MD file:', error));
-    }
-  }, [githubLink]);
-
   if (locale !== LanguageEnum.ENGLISH) {
     return null;
   }
@@ -166,7 +174,7 @@ export default function LLMActions(props: LLMActionsProps) {
           className={classes.mainButton}
           onClick={handleDefaultClick}
           title={t(defaultOption.descKey)}
-          disabled={copyStatus === 'loading' || !mdContent}
+          disabled={copyStatus === 'loading' || (!mdContent && !githubLink)}
         >
           <span
             className={clsx(classes.buttonIcon, {
@@ -182,12 +190,14 @@ export default function LLMActions(props: LLMActionsProps) {
           onClick={toggleDropdown}
           aria-expanded={isOpen}
         >
-          <ChevronDown
-            size={16}
+          <span
             className={clsx(classes.chevron, {
               [classes.chevronOpen]: isOpen,
             })}
-          />
+            aria-hidden="true"
+          >
+            ▾
+          </span>
         </button>
       </div>
 

--- a/src/components/cookieConsent/LazyCookieConsent.tsx
+++ b/src/components/cookieConsent/LazyCookieConsent.tsx
@@ -1,0 +1,28 @@
+import { ComponentType, useEffect, useState } from 'react';
+
+const COOKIE_CONSENT_NAME = 'CookieConsent';
+
+export default function LazyCookieConsent() {
+  const [ConsentComponent, setConsentComponent] =
+    useState<ComponentType | null>(null);
+
+  useEffect(() => {
+    if (document.cookie.includes(`${COOKIE_CONSENT_NAME}=`)) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      import('./index')
+        .then(mod => {
+          setConsentComponent(() => mod.default);
+        })
+        .catch(error => console.error('Failed to load cookie consent:', error));
+    }, 3500);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  return ConsentComponent ? <ConsentComponent /> : null;
+}

--- a/src/components/localization/CreateDocDetailProps.ts
+++ b/src/components/localization/CreateDocDetailProps.ts
@@ -9,6 +9,14 @@ import { GetStaticProps } from 'next';
 import { generateApiMenuDataOfCurrentVersion } from '@/utils/apiReference';
 import { LanguageEnum } from '@/types/localization';
 import { DocDetailPage } from '@/components/localization/DocDetail';
+import {
+  getDocHreflangUrls,
+  getDocCanonicalUrl,
+} from '@/components/localization/utils';
+import {
+  stripMdListDataForClient,
+  stripMenuForClient,
+} from '@/utils/client-doc-data';
 
 export default DocDetailPage;
 
@@ -57,6 +65,22 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
       docVersion: currentVersion,
     });
     const menu = [...docMenu, outerApiMenuItem];
+    const latestVersionMds = mdListData.find(
+      item => item.version === latestVersion
+    )?.mds;
+    const hreflangUrls = getDocHreflangUrls({
+      version: currentVersion,
+      latestVersion,
+      docId: id,
+      availableLanguages,
+    });
+    const canonicalUrl = getDocCanonicalUrl({
+      lang,
+      version: currentVersion,
+      latestVersion,
+      docId: id,
+      latestVersionMds,
+    });
 
     const docDetailContentList = generateAllContentDataOfSingleVersion({
       version: currentVersion,
@@ -90,10 +114,11 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
         latestVersion,
         lang,
         versions,
-        menus: menu,
+        menus: stripMenuForClient(menu),
         id,
-        mdListData,
-        availableLanguages,
+        mdListData: stripMdListDataForClient(mdListData, id),
+        hreflangUrls,
+        canonicalUrl,
       },
     };
   };

--- a/src/components/localization/CreateDocHomeProps.ts
+++ b/src/components/localization/CreateDocHomeProps.ts
@@ -8,16 +8,20 @@ import {
   generateMenuDataOfCurrentVersion,
   getAvailableLanguagesForDoc,
 } from '@/utils/docs';
+import { getDocHreflangUrls } from '@/components/localization/utils';
+import {
+  stripMdListDataForClient,
+  stripMenuForClient,
+} from '@/utils/client-doc-data';
 
 export const createDocHomeProps = (lang: LanguageEnum, version = '') => {
   const getPageStaticProps = async () => {
     const { versions, latestVersion } = generateDocVersionInfo();
     const currentVersion = version || latestVersion;
-    const { content: homeContent, filePath } =
-      generateHomePageDataOfSingleVersion({
-        version: currentVersion,
-        lang,
-      });
+    const { content: homeContent } = generateHomePageDataOfSingleVersion({
+      version: currentVersion,
+      lang,
+    });
     const { frontMatter: latestBlogData } = generateAllBlogContentList()[0];
     const docMenu = generateMenuDataOfCurrentVersion({
       docVersion: currentVersion,
@@ -35,6 +39,11 @@ export const createDocHomeProps = (lang: LanguageEnum, version = '') => {
     const availableLanguages = getAvailableLanguagesForDoc({
       version: currentVersion,
     });
+    const hreflangUrls = getDocHreflangUrls({
+      version: currentVersion,
+      latestVersion,
+      availableLanguages,
+    });
 
     return {
       props: {
@@ -45,9 +54,9 @@ export const createDocHomeProps = (lang: LanguageEnum, version = '') => {
         lang,
         versions,
         blog: latestBlogData,
-        menus: menu,
-        mdListData,
-        availableLanguages,
+        menus: stripMenuForClient(menu),
+        mdListData: stripMdListDataForClient(mdListData, 'home'),
+        hreflangUrls,
       },
     };
   };

--- a/src/components/localization/DocDetail.tsx
+++ b/src/components/localization/DocDetail.tsx
@@ -14,12 +14,7 @@ import classes from '@/styles/docDetail.module.css';
 import clsx from 'clsx';
 import { DocDetailPageProps } from '@/types/docs';
 import { LanguageEnum } from '@/types/localization';
-import {
-  getHomePageLink,
-  getSeoUrl,
-  getDocCanonicalUrl,
-  getDocHreflangUrls,
-} from '@/components/localization/utils';
+import { getHomePageLink, getSeoUrl } from '@/components/localization/utils';
 import { useBreadcrumbLabels } from '@/hooks/use-breadcrumb-lables';
 import { useAnchorEventListener } from '@/hooks/use-anchor-event-listener';
 
@@ -34,7 +29,8 @@ export function DocDetailPage(props: DocDetailPageProps) {
     id: currentId,
     mdListData,
     lang,
-    availableLanguages,
+    hreflangUrls,
+    canonicalUrl,
   } = props;
 
   const {
@@ -47,22 +43,6 @@ export function DocDetailPage(props: DocDetailPageProps) {
     frontMatter,
   } = homeData;
   const seoUrl = getSeoUrl({ lang, version, latestVersion, docId: currentId });
-  const latestVersionMds = mdListData?.find(
-    item => item.version === latestVersion
-  )?.mds;
-  const canonicalUrl = getDocCanonicalUrl({
-    lang,
-    version,
-    latestVersion,
-    docId: currentId,
-    latestVersionMds,
-  });
-  const hreflangUrls = getDocHreflangUrls({
-    version,
-    latestVersion,
-    docId: currentId,
-    availableLanguages,
-  });
   const homePageLink = getHomePageLink({ lang, version, latestVersion });
 
   const isEN = lang === LanguageEnum.ENGLISH;

--- a/src/components/localization/DocHome.tsx
+++ b/src/components/localization/DocHome.tsx
@@ -12,7 +12,6 @@ import {
   getHomePageLink,
   getSeoUrl,
   getDocCanonicalUrl,
-  getDocHreflangUrls,
 } from '@/components/localization/utils';
 
 export interface DocHomePageProps {
@@ -25,7 +24,7 @@ export interface DocHomePageProps {
   blog: BlogFrontMatterType;
   menus: FinalMenuStructureType[];
   mdListData: AllMdVersionIdType[];
-  availableLanguages: LanguageEnum[];
+  hreflangUrls: { lang: string; url: string }[];
 }
 
 // latest version's home page
@@ -40,15 +39,10 @@ export function DocHomepage(props: DocHomePageProps) {
     mdListData,
     lang,
     latestVersion,
-    availableLanguages,
+    hreflangUrls,
   } = props;
   const seoUrl = getSeoUrl({ lang, version, latestVersion });
   const canonicalUrl = getDocCanonicalUrl({ lang, version, latestVersion });
-  const hreflangUrls = getDocHreflangUrls({
-    version,
-    latestVersion,
-    availableLanguages,
-  });
   const homePageLink = getHomePageLink({ lang, version, latestVersion });
 
   return (

--- a/src/components/search/agloia.tsx
+++ b/src/components/search/agloia.tsx
@@ -1,4 +1,6 @@
 import { DocSearch, DocSearchTranslations } from '@docsearch/react';
+import '@docsearch/css';
+import 'instantsearch.css/themes/reset.css';
 import classes from './agloia.module.css';
 import { useTranslation } from 'react-i18next';
 import { LanguageEnum } from '@/types/localization';

--- a/src/components/treeView/ExpansionTreeView.module.css
+++ b/src/components/treeView/ExpansionTreeView.module.css
@@ -62,32 +62,6 @@
   overflow: hidden;
 }
 
-.collapsibleContent[data-state='open'] {
-  animation: treeViewSlideDown 0.2s ease-out;
-}
-
-.collapsibleContent[data-state='closed'] {
-  animation: treeViewSlideUp 0.2s ease-out;
-}
-
-@keyframes treeViewSlideDown {
-  from {
-    height: 0;
-  }
-  to {
-    height: var(--radix-collapsible-content-height);
-  }
-}
-
-@keyframes treeViewSlideUp {
-  from {
-    height: var(--radix-collapsible-content-height);
-  }
-  to {
-    height: 0;
-  }
-}
-
 .selected {
   a {
     color: var(--color-text-primary);

--- a/src/components/treeView/ExpansionTreeView.tsx
+++ b/src/components/treeView/ExpansionTreeView.tsx
@@ -8,7 +8,6 @@ import { findActiveMenuItem } from '@/utils';
 import { useRouter } from 'next/router';
 import { LanguageEnum } from '@/types/localization';
 import { getLinkPrefix } from './utils';
-import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
 
 const SCROLL_TOP = '@@scroll|menu';
 
@@ -185,7 +184,7 @@ const ExpansionTreeView = (props: ExpansionTreeViewPropsType) => {
     return (
       <li key={hasChildren ? id : `child-${id}-${href}`} className={itemClassName}>
         {hasChildren ? (
-          <Collapsible open={isExpanded}>
+          <>
             <div
               className={clsx(styles.treeItemLabel, {
                 [styles.selected]: isSelected,
@@ -201,12 +200,14 @@ const ExpansionTreeView = (props: ExpansionTreeViewPropsType) => {
               </span>
               <span>{label}</span>
             </div>
-            <CollapsibleContent className={styles.collapsibleContent}>
-              <ul className={styles.treeItemChildren}>
-                {children.map(child => generateTreeItem(child))}
-              </ul>
-            </CollapsibleContent>
-          </Collapsible>
+            {isExpanded && (
+              <div className={styles.collapsibleContent}>
+                <ul className={styles.treeItemChildren}>
+                  {children.map(child => generateTreeItem(child))}
+                </ul>
+              </div>
+            )}
+          </>
         ) : (
           <div
             className={clsx(styles.treeItemLabel, styles.treeItemLeaf, {

--- a/src/http/hooks.js
+++ b/src/http/hooks.js
@@ -1,39 +1,4 @@
 import { useState, useEffect } from 'react';
-import { getGithubCommits } from '@/http/milvus';
-import dayjs from 'dayjs';
-
-export function useGithubCommits({ commitPath, version }) {
-  const [commitInfo, setCommitInfo] = useState({
-    message: '',
-    date: '',
-    commitUrl: '',
-    source: '',
-  });
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const res = await getGithubCommits(commitPath, version);
-        if (res.status === 200 && res.data.length) {
-          const lastCommit = res.data[0];
-          const message = lastCommit.commit.message.split('\n')[0];
-          const date = lastCommit.commit.committer.date;
-          const commitUrl = lastCommit.html_url;
-          const formatDate = dayjs(date).format('YYYY-MM-DD HH:mm:ss');
-          const source = commitPath.startWidth('http')
-            ? commitPath
-            : `https://github.com/milvus-io/milvus-docs/blob${commitPath}`;
-          setCommitInfo({ commitUrl, date: formatDate, source, message });
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    fetchData();
-  }, [commitPath, version]);
-
-  return commitInfo;
-}
 
 export function getCurrentSize() {
   if (typeof window !== 'undefined') {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import CustomCookieConsent from '@/components/cookieConsent';
+import LazyCookieConsent from '@/components/cookieConsent/LazyCookieConsent';
 import InkeepChatButtonContainer from '@/components/inkeep/InkeepChatButton';
 import { ErrorBoundary } from 'next/dist/client/components/error-boundary';
 import Head from 'next/head';
@@ -56,7 +56,7 @@ function MyApp({ Component, pageProps }) {
             defer
           />
           <InkeepChatButtonContainer />
-          <CustomCookieConsent />
+          <LazyCookieConsent />
         </HubspotProvider>
       </StoreProvider>
     </ErrorBoundary>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -21,7 +21,7 @@ export default function Document(props) {
           dangerouslySetInnerHTML={{
             __html: `!function(){var hrefs=${JSON.stringify(
               FONT_STYLESHEET_HREFS
-            )};function loadFonts(){hrefs.forEach(function(href){var link=document.createElement('link');link.rel='stylesheet';link.href=href;document.head.appendChild(link);});}if('requestIdleCallback'in window){requestIdleCallback(loadFonts,{timeout:1500});}else{setTimeout(loadFonts,0);}}();`,
+            )};function loadFonts(){hrefs.forEach(function(href){var link=document.createElement('link');link.rel='stylesheet';link.href=href;document.head.appendChild(link);});}if('requestIdleCallback'in window){requestIdleCallback(loadFonts,{timeout:3000});}else{setTimeout(loadFonts,2000);}}();`,
           }}
         />
         <noscript>

--- a/src/parts/docs/docContent/index.tsx
+++ b/src/parts/docs/docContent/index.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
-import GitCommitInfo from '../GitCommitInfo';
-import { useGithubCommits } from '../../../http/hooks';
 import classes from './index.module.css';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import Breadcrumb from '@/components/breadcrumb';
-import LLMActions, {
-  PageAction,
-  OptionItem,
-} from '@/components/LLMActions';
+import LLMActions, { PageAction, OptionItem } from '@/components/LLMActions';
 import { CopyIcon } from '@/components/icons';
 import { RightTopArrowIcon } from '@/components/icons/RightTopArrow';
 import { OpenAIIcon, ClaudeAIIcon } from '@/components/icons/AI';
@@ -82,7 +77,6 @@ export default function DocContent(props: DocContentPropsType) {
     apiCategory,
     lang = 'en',
   } = props;
-  const { t } = useTranslation('common');
   const { t: headerTrans } = useTranslation('header');
 
   const docLink = lang == 'en' ? `/docs` : `/docs/${lang}`;
@@ -128,11 +122,6 @@ export default function DocContent(props: DocContentPropsType) {
   //   title: "Didn't find what you need?",
   // };
 
-  const commitInfo = useGithubCommits({
-    commitPath,
-    version,
-  });
-
   return (
     <div className={classes.docPostWrapper}>
       <div className={classes.topBar}>
@@ -145,16 +134,12 @@ export default function DocContent(props: DocContentPropsType) {
           ]}
           lang={lang}
         />
-        <LLMActions options={docPageOptions} githubLink={`${MILVUS_RAW_DOCS_BASE_URL}${commitPath}`} />
+        <LLMActions
+          options={docPageOptions}
+          githubLink={`${MILVUS_RAW_DOCS_BASE_URL}${commitPath}`}
+        />
       </div>
       <DocHtmlContent htmlContent={htmlContent} type={type} />
-      {commitInfo?.message && (
-        <GitCommitInfo
-          commitInfo={commitInfo}
-          mdId={mdId}
-          commitTrans={t('v3trans.docs.commitTrans')}
-        />
-      )}
       {/* <ScoredFeedback trans={trans} pageId={mdId} /> */}
     </div>
   );

--- a/src/parts/docs/leftNavTree/index.module.css
+++ b/src/parts/docs/leftNavTree/index.module.css
@@ -13,6 +13,11 @@ html[lang='ar'] {
   width: 100%;
 }
 
+.searchPlaceholder {
+  height: 44px;
+  flex: 0 0 auto;
+}
+
 .tree {
   overflow: auto;
 }

--- a/src/parts/docs/leftNavTree/index.tsx
+++ b/src/parts/docs/leftNavTree/index.tsx
@@ -1,4 +1,4 @@
-import { AlgoliaSearch } from '@/components/search/agloia';
+import dynamic from 'next/dynamic';
 import ExpansionTreeView from '@/components/treeView/ExpansionTreeView';
 import VersionSelector from '@/components/versionSelector';
 import { LanguageEnum } from '@/types/localization';
@@ -9,10 +9,42 @@ import {
 } from '@/types/docs';
 import clsx from 'clsx';
 
-import '@docsearch/css';
-import 'instantsearch.css/themes/reset.css';
-
 import classes from './index.module.css';
+
+const AlgoliaSearch = dynamic(
+  () =>
+    new Promise<typeof import('@/components/search/agloia').AlgoliaSearch>(
+      resolve => {
+        const load = () => {
+          import('@/components/search/agloia').then(mod => {
+            resolve(mod.AlgoliaSearch);
+          });
+        };
+
+        if (typeof window === 'undefined') {
+          load();
+          return;
+        }
+
+        const browserWindow = window as Window & {
+          requestIdleCallback?: (
+            callback: IdleRequestCallback,
+            options?: IdleRequestOptions
+          ) => number;
+        };
+
+        if (browserWindow.requestIdleCallback) {
+          browserWindow.requestIdleCallback(load, { timeout: 2500 });
+        } else {
+          setTimeout(load, 1500);
+        }
+      }
+    ),
+  {
+    ssr: false,
+    loading: () => <div className={classes.searchPlaceholder} />,
+  }
+);
 
 interface LeftNavSectionProps {
   tree: FinalMenuStructureType[];

--- a/src/types/docs.ts
+++ b/src/types/docs.ts
@@ -44,12 +44,13 @@ export interface OriginMenuStructureType {
 export interface FinalMenuStructureType {
   label: string;
   id: string;
-  isMenu: boolean;
-  externalLink: string;
+  isMenu?: boolean;
+  externalLink?: string;
   href: string;
-  parentId: string;
+  parentId?: string;
   parentIds: string[];
-  level: number;
+  level?: number;
+  order?: number;
   children: FinalMenuStructureType[];
 }
 
@@ -138,6 +139,7 @@ export interface DocDetailPageProps {
     editPath: string;
     frontMatter: DocFrontMatterType;
   };
+  canonicalUrl: string;
   blog: BlogFrontMatterType | null;
   version: string;
   lang: LanguageEnum;
@@ -146,7 +148,7 @@ export interface DocDetailPageProps {
   menus: FinalMenuStructureType[];
   id: string;
   mdListData: AllMdVersionIdType[];
-  availableLanguages: LanguageEnum[];
+  hreflangUrls: { lang: string; url: string }[];
 }
 
 export interface DocAnchorItemType {

--- a/src/utils/client-doc-data.ts
+++ b/src/utils/client-doc-data.ts
@@ -1,0 +1,42 @@
+import { AllMdVersionIdType, FinalMenuStructureType } from '@/types/docs';
+
+const CLIENT_MENU_KEYS = [
+  'id',
+  'label',
+  'href',
+  'parentIds',
+  'externalLink',
+  'children',
+] as const;
+
+export type ClientMenuItem = Pick<
+  FinalMenuStructureType,
+  (typeof CLIENT_MENU_KEYS)[number]
+>;
+
+export const stripMenuForClient = (
+  menu: FinalMenuStructureType[]
+): ClientMenuItem[] => {
+  return menu.map(item => ({
+    id: item.id,
+    label: item.label,
+    href: item.href,
+    parentIds: item.parentIds || [],
+    externalLink: item.externalLink || '',
+    children: stripMenuForClient(item.children || []),
+  }));
+};
+
+export const stripMdListDataForClient = (
+  mdListData: AllMdVersionIdType[],
+  currentMdId?: string
+): AllMdVersionIdType[] => {
+  if (!currentMdId || currentMdId === 'home') {
+    return [];
+  }
+
+  return mdListData.map(({ version, mds }) => ({
+    version,
+    mds: mds.includes(currentMdId) ? [currentMdId] : [],
+  }));
+};


### PR DESCRIPTION
## Summary
- Reduce docs page `__NEXT_DATA__` by stripping menu/version metadata to fields needed by the client and precomputing canonical/hreflang data server-side.
- Defer non-critical docs UI work by lazy-loading DocSearch, cookie consent, and markdown fetching for LLM copy actions.
- Remove docs initial GitHub commit lookup and Radix collapsible usage from the critical path.

## Test plan
- [x] `git diff --cached --check`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec next build --no-lint` (compile passed; static generation fails on existing `/use-cases` CMS timeout: `connect ETIMEDOUT 172.16.20.181:1337`)
