### PR TITLE
fix: cache SSG Next data responses

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -453,6 +453,20 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  # Next.js SSG data for blog and docs pages.
+  # The build ID is part of the URL, so these responses are safe to cache in browsers.
+  # Keep this before the generic *.json location.
+  location ~ ^/_next/data/[^/]+/(?:(?:blog|docs)|(?:zh-hant|zh|ja|fr|ko|ru|de|es|pt|it|ar|id)/blog)(?:/.*)?\.json$ {
+    proxy_pass http://localhost:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
+
   location ~* \.(svg|png|jpg|jpeg|gif|ico|webp|css|js|xml|txt|json)$ {
     proxy_pass http://localhost:3000;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- Add browser immutable caching for Next.js SSG data JSON under blog and docs routes
- Keep dynamic/non-whitelisted Next data responses on the existing generic JSON proxy path

## Test plan
- [x] `docker run --rm -v "$PWD/conf/conf.d/client.conf:/etc/nginx/conf.d/client.conf" zilliz/zilliz-web-runner sh -c 'rm -f /etc/nginx/conf.d/default.conf; nginx -t -c /etc/nginx/nginx.conf'`
- [x] Temporary Nginx + Node upstream test: verified blog/docs data gets `Cache-Control: public, max-age=31536000, immutable`, non-blog/docs data is unchanged, and Chrome only hits upstream once for repeated docs data fetches
