### PR TITLE
fix: preserve homepage app card image ratio

### DIFF
--- a/src/parts/home/developSection/index.module.css
+++ b/src/parts/home/developSection/index.module.css
@@ -55,7 +55,9 @@
           text-align: center;
 
           img {
+            display: block;
             width: 100%;
+            height: auto;
           }
         }
 


### PR DESCRIPTION
## Summary
- Prevent homepage GenAI app card images from being stretched by preserving their intrinsic aspect ratio

## Test plan
- [x] `pnpm lint` (Next.js prompted for ESLint setup and exited with code 1)
- [x] `git commit -S -s -m "fix: preserve homepage app card image ratio"` (pre-commit Nginx config test passed)