### PR TITLE
fix: defer docs and api detail page generation

### DIFF
--- a/src/components/localization/CreateDocDetailProps.ts
+++ b/src/components/localization/CreateDocDetailProps.ts
@@ -22,25 +22,21 @@ export default DocDetailPage;
 
 export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
   const getPageStaticPaths = () => {
-    const { latestVersion } = generateDocVersionInfo();
-    const currentVersion = version || latestVersion;
-    const latestDocContentList = generateAllContentDataOfSingleVersion({
-      version: currentVersion,
-      lang,
-    });
-
-    const paths = latestDocContentList.map(v => ({
-      params: { id: v.frontMatter.id },
-    }));
-
     return {
-      paths,
-      fallback: false,
+      paths: [],
+      fallback: 'blocking',
     };
   };
 
   const getPageStaticProps: GetStaticProps = async context => {
     const { params } = context;
+
+    if (!params?.id || Array.isArray(params.id)) {
+      return {
+        notFound: true,
+        revalidate: 60,
+      };
+    }
 
     const id = params.id as string;
     const { versions, latestVersion } = generateDocVersionInfo();
@@ -84,12 +80,21 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
       lang,
     });
 
+    const targetDoc = docDetailContentList.find(v => v.frontMatter.id === id);
+
+    if (!targetDoc) {
+      return {
+        notFound: true,
+        revalidate: 60,
+      };
+    }
+
     const {
       content: docDetailContent,
       frontMatter,
       editPath,
       propsInfo,
-    } = docDetailContentList.find(v => v.frontMatter.id === id);
+    } = targetDoc;
 
     const { codeList, anchorList } = propsInfo;
     const headingContent = anchorList?.[0]?.label;
@@ -116,6 +121,7 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
         hreflangUrls,
         canonicalUrl,
       },
+      revalidate: 86400,
     };
   };
 

--- a/src/pages/api-reference/[language]/[version]/[...slug].tsx
+++ b/src/pages/api-reference/[language]/[version]/[...slug].tsx
@@ -8,11 +8,9 @@ import DocContent from '@/parts/docs/docContent';
 import { useMemo } from 'react';
 import {
   generateApiMenuAndContentDataOfAllVersions,
-  generateApiMenuAndContentDataOfSingleVersion,
   generateApiReferenceVersionsInfo,
 } from '@/utils/apiReference';
 import {
-  ApiFileDateInfoType,
   ApiReferenceLanguageEnum,
   ApiReferenceRouteEnum,
   FinalMenuStructureType,
@@ -242,63 +240,34 @@ export default function Template(props: ApiDetailPageProps) {
 }
 
 export const getStaticPaths = () => {
-  const apiData = generateApiReferenceVersionsInfo();
-
-  const result = apiData
-    .map(data => {
-      const { language, versions } = data;
-      const ApiDataOfCurLang = versions.map(version =>
-        generateApiMenuAndContentDataOfSingleVersion({
-          version,
-          language,
-        })
-      );
-      return {
-        language,
-        versions,
-        data: ApiDataOfCurLang,
-      };
-    })
-    // Restful paths have been moved to api-reference/restful/[version]/[...slug].tsx
-    .filter(item => item.language !== ApiReferenceLanguageEnum.Restful);
-
-  let routers: ApiFileDateInfoType[] = [];
-  result.forEach(({ data }) => {
-    data.forEach(v => {
-      routers = routers.concat(v.contentList);
-    });
-  });
-
-  /**
-   * 1. /pymilvus/v2.4.x/DataImport/LocalBulkWriter/append_row.md
-   * 2. /pymilvus/v2.4.x/append_rows.md
-   */
-  const paths = routers.map(v => {
-    const {
-      frontMatter: { id, parentIds, category, version },
-    } = v;
-    const slug = [...parentIds, id];
-    return {
-      params: {
-        language: category,
-        version,
-        slug,
-      },
-    };
-  });
-
   return {
-    paths: paths,
-    fallback: false,
+    paths: [],
+    fallback: 'blocking',
   };
 };
 
 export const getStaticProps: GetStaticProps = async context => {
-  const { version } = context.params;
-  const languageCategory: ApiReferenceRouteEnum = context.params
-    .language as ApiReferenceRouteEnum;
+  const { params } = context;
 
-  const slug = context.params.slug as string[];
+  if (
+    !params?.version ||
+    Array.isArray(params.version) ||
+    !params?.language ||
+    Array.isArray(params.language) ||
+    !params?.slug ||
+    !Array.isArray(params.slug)
+  ) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
+  const { version } = params;
+  const languageCategory: ApiReferenceRouteEnum =
+    params.language as ApiReferenceRouteEnum;
+
+  const slug = params.slug as string[];
   const routeCategoryToLanguage: Record<
     ApiReferenceRouteEnum,
     ApiReferenceLanguageEnum
@@ -312,28 +281,51 @@ export const getStaticProps: GetStaticProps = async context => {
     [ApiReferenceRouteEnum.Restful]: ApiReferenceLanguageEnum.Restful,
   };
 
+  const apiLanguage = routeCategoryToLanguage[languageCategory];
+
+  if (!apiLanguage || apiLanguage === ApiReferenceLanguageEnum.Restful) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
   const apiData = generateApiReferenceVersionsInfo();
   const { versions, latestVersion } =
-    apiData.find(
-      v => v.language === routeCategoryToLanguage[languageCategory]
-    ) || {};
+    apiData.find(v => v.language === apiLanguage) || {};
+
+  if (!versions?.includes(version)) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
   const curCategoryData = generateApiMenuAndContentDataOfAllVersions({
-    language: routeCategoryToLanguage[languageCategory],
+    language: apiLanguage,
     withContent: true,
   });
 
   const { menuData, contentList: contentData } =
     curCategoryData.find(v => v.version === version) || {};
 
-  const { frontMatter, content: apiContent } =
-    contentData.find(v => {
-      const {
-        frontMatter: { id, parentIds },
-      } = v;
-      const targetSlug = slug.join('/');
-      const sourceSlug = [...parentIds, id].join('/');
-      return targetSlug === sourceSlug;
-    }) || {};
+  const targetContent = contentData?.find(v => {
+    const {
+      frontMatter: { id, parentIds },
+    } = v;
+    const targetSlug = slug.join('/');
+    const sourceSlug = [...parentIds, id].join('/');
+    return targetSlug === sourceSlug;
+  });
+
+  if (!targetContent) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
+  const { frontMatter, content: apiContent } = targetContent;
 
   const { tree: doc, codeList } = markdownToHtml(apiContent || '', {
     showAnchor: true,
@@ -346,7 +338,7 @@ export const getStaticProps: GetStaticProps = async context => {
 
   const curCategoryContentDataOfAllVersion =
     generateApiMenuAndContentDataOfAllVersions({
-      language: routeCategoryToLanguage[languageCategory],
+      language: apiLanguage,
       withContent: false,
     }).map(v => ({
       version: v.version,
@@ -379,5 +371,6 @@ export const getStaticProps: GetStaticProps = async context => {
         path: metaPath,
       },
     },
+    revalidate: 86400,
   };
 };

--- a/src/pages/api-reference/restful/[version]/[...slug].tsx
+++ b/src/pages/api-reference/restful/[version]/[...slug].tsx
@@ -8,7 +8,6 @@ import { ABSOLUTE_BASE_URL } from '@/consts';
 import LeftNavSection from '@/parts/docs/leftNavTree';
 import {
   AllMdVersionIdType,
-  ApiFileDateInfoType,
   ApiReferenceLanguageEnum,
   ApiReferenceMetaInfoEnum,
   ApiReferenceRouteEnum,
@@ -22,7 +21,6 @@ import {
 } from '@/utils/mdx';
 import {
   generateRestfulMenuAndContentDataOfAllVersions,
-  generateRestfulMenuAndContentDataOfSingleVersion,
   generateRestfulVersionsInfo,
   SPLIT_FLAG,
 } from '@/utils/restful';
@@ -156,54 +154,38 @@ export default function RestfulApiReference(props: {
 }
 
 export async function getStaticPaths() {
-  const restfulInfo = generateRestfulVersionsInfo();
-  const result = restfulInfo.map(data => {
-    const { language, versions } = data;
-    const ApiDataOfCurLang = versions.map(version =>
-      generateRestfulMenuAndContentDataOfSingleVersion({
-        version,
-        language,
-      })
-    );
-    return {
-      language,
-      versions,
-      data: ApiDataOfCurLang,
-    };
-  });
-
-  let routers: ApiFileDateInfoType[] = [];
-  result.forEach(({ data }) => {
-    data.forEach(v => {
-      routers = routers.concat(v.contentList);
-    });
-  });
-
-  const paths = routers.map(v => {
-    const {
-      frontMatter: { id, parentIds, version },
-    } = v;
-    const slug = [...parentIds, id.replace('.mdx', '.md')];
-    return {
-      params: {
-        version,
-        slug,
-      },
-    };
-  });
-
   return {
-    paths,
-    fallback: false,
+    paths: [],
+    fallback: 'blocking',
   };
 }
 
 export async function getStaticProps({ params }) {
+  if (
+    !params?.version ||
+    Array.isArray(params.version) ||
+    !params?.slug ||
+    !Array.isArray(params.slug)
+  ) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
   const { version, slug } = params;
   const restfulInfo = generateRestfulVersionsInfo();
   const { versions, latestVersion } =
     restfulInfo.find(v => v.language === ApiReferenceLanguageEnum.Restful) ||
     {};
+
+  if (!versions?.includes(version)) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
   const curCategoryData = generateRestfulMenuAndContentDataOfAllVersions({
     language: ApiReferenceLanguageEnum.Restful,
     withContent: true,
@@ -211,15 +193,23 @@ export async function getStaticProps({ params }) {
 
   const { menuData, contentList: contentData } =
     curCategoryData.find(v => v.version === version) || {};
-  const { frontMatter, content } =
-    contentData.find(v => {
-      const {
-        frontMatter: { id, parentIds },
-      } = v;
-      const targetSlug = slug.join('/');
-      const sourceSlug = [...parentIds, id].join('/');
-      return targetSlug === sourceSlug;
-    }) || {};
+  const targetContent = contentData?.find(v => {
+    const {
+      frontMatter: { id, parentIds },
+    } = v;
+    const targetSlug = slug.join('/');
+    const sourceSlug = [...parentIds, id].join('/');
+    return targetSlug === sourceSlug;
+  });
+
+  if (!targetContent) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+
+  const { frontMatter, content } = targetContent;
 
   const { exports } = await getVariablesFromMDX(content);
   const mdxSource = await serialize(content, {
@@ -273,5 +263,6 @@ export async function getStaticProps({ params }) {
         path: metaPath,
       },
     },
+    revalidate: 86400,
   };
 }


### PR DESCRIPTION
## Summary
- Defer docs detail page generation with `fallback: blocking` and ISR.
- Defer API reference detail page generation with `fallback: blocking` and ISR.
- Return `notFound` for invalid fallback params or missing docs/API pages.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `NEXT_PUBLIC_CMS_BASE_URL=https://cms.zilliz.cc NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max_old_space_size=8192 pnpm exec next build`
- [x] `NEXT_PUBLIC_CMS_BASE_URL=https://cms.zilliz.cc NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max_old_space_size=8192 pnpm exec next start -p 3000`
- [x] `curl -I -s http://localhost:3000/docs/install_standalone-docker.md`
- [x] `curl -I -s http://localhost:3000/api-reference/pymilvus/v2.6.x/About.md`