### PR TITLE
fix: include docs source for on-demand pages

### DIFF
--- a/Builder.Dockerfile
+++ b/Builder.Dockerfile
@@ -42,6 +42,7 @@ COPY supervisord.conf /etc/supervisord.conf
 
 COPY --from=builder /app/.next /app/.next
 COPY --from=builder /app/src/blogs /app/src/blogs
+COPY --from=builder /app/src/docs /app/src/docs
 COPY --from=builder /app/public /app/public
 COPY --from=builder /app/global-stats.json /app/global-stats.json
 COPY --from=dependency /app/node_modules /app/node_modules

--- a/Preview.Dockerfile
+++ b/Preview.Dockerfile
@@ -40,6 +40,7 @@ COPY supervisord.conf /etc/supervisord.conf
 
 COPY --from=builder /app/.next /app/.next
 COPY --from=builder /app/src/blogs /app/src/blogs
+COPY --from=builder /app/src/docs /app/src/docs
 COPY --from=builder /app/public /app/public
 COPY --from=builder /app/global-stats.json /app/global-stats.json
 COPY --from=dependency /app/node_modules /app/node_modules


### PR DESCRIPTION
## Summary
- Copy `src/docs` into the runtime Docker image so fallback/ISR docs and API reference pages can read source markdown after deployment.
- Apply the same runtime copy to both preview and production Dockerfiles.

## Test plan
- [x] `git cherry-pick -S -x e3a2df7`
- [ ] N/A (Docker image rebuild/deploy required to verify preview 500 fix)