### PR TITLE
revert: restore static docs and api page generation

### DIFF
--- a/Builder.Dockerfile
+++ b/Builder.Dockerfile
@@ -42,7 +42,6 @@ COPY supervisord.conf /etc/supervisord.conf
 
 COPY --from=builder /app/.next /app/.next
 COPY --from=builder /app/src/blogs /app/src/blogs
-COPY --from=builder /app/src/docs /app/src/docs
 COPY --from=builder /app/public /app/public
 COPY --from=builder /app/global-stats.json /app/global-stats.json
 COPY --from=dependency /app/node_modules /app/node_modules

--- a/Preview.Dockerfile
+++ b/Preview.Dockerfile
@@ -40,7 +40,6 @@ COPY supervisord.conf /etc/supervisord.conf
 
 COPY --from=builder /app/.next /app/.next
 COPY --from=builder /app/src/blogs /app/src/blogs
-COPY --from=builder /app/src/docs /app/src/docs
 COPY --from=builder /app/public /app/public
 COPY --from=builder /app/global-stats.json /app/global-stats.json
 COPY --from=dependency /app/node_modules /app/node_modules

--- a/src/components/localization/CreateDocDetailProps.ts
+++ b/src/components/localization/CreateDocDetailProps.ts
@@ -22,21 +22,25 @@ export default DocDetailPage;
 
 export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
   const getPageStaticPaths = () => {
+    const { latestVersion } = generateDocVersionInfo();
+    const currentVersion = version || latestVersion;
+    const latestDocContentList = generateAllContentDataOfSingleVersion({
+      version: currentVersion,
+      lang,
+    });
+
+    const paths = latestDocContentList.map(v => ({
+      params: { id: v.frontMatter.id },
+    }));
+
     return {
-      paths: [],
-      fallback: 'blocking',
+      paths,
+      fallback: false,
     };
   };
 
   const getPageStaticProps: GetStaticProps = async context => {
     const { params } = context;
-
-    if (!params?.id || Array.isArray(params.id)) {
-      return {
-        notFound: true,
-        revalidate: 60,
-      };
-    }
 
     const id = params.id as string;
     const { versions, latestVersion } = generateDocVersionInfo();
@@ -80,21 +84,12 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
       lang,
     });
 
-    const targetDoc = docDetailContentList.find(v => v.frontMatter.id === id);
-
-    if (!targetDoc) {
-      return {
-        notFound: true,
-        revalidate: 60,
-      };
-    }
-
     const {
       content: docDetailContent,
       frontMatter,
       editPath,
       propsInfo,
-    } = targetDoc;
+    } = docDetailContentList.find(v => v.frontMatter.id === id);
 
     const { codeList, anchorList } = propsInfo;
     const headingContent = anchorList?.[0]?.label;
@@ -121,7 +116,6 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
         hreflangUrls,
         canonicalUrl,
       },
-      revalidate: 86400,
     };
   };
 

--- a/src/pages/api-reference/[language]/[version]/[...slug].tsx
+++ b/src/pages/api-reference/[language]/[version]/[...slug].tsx
@@ -8,9 +8,11 @@ import DocContent from '@/parts/docs/docContent';
 import { useMemo } from 'react';
 import {
   generateApiMenuAndContentDataOfAllVersions,
+  generateApiMenuAndContentDataOfSingleVersion,
   generateApiReferenceVersionsInfo,
 } from '@/utils/apiReference';
 import {
+  ApiFileDateInfoType,
   ApiReferenceLanguageEnum,
   ApiReferenceRouteEnum,
   FinalMenuStructureType,
@@ -240,34 +242,63 @@ export default function Template(props: ApiDetailPageProps) {
 }
 
 export const getStaticPaths = () => {
+  const apiData = generateApiReferenceVersionsInfo();
+
+  const result = apiData
+    .map(data => {
+      const { language, versions } = data;
+      const ApiDataOfCurLang = versions.map(version =>
+        generateApiMenuAndContentDataOfSingleVersion({
+          version,
+          language,
+        })
+      );
+      return {
+        language,
+        versions,
+        data: ApiDataOfCurLang,
+      };
+    })
+    // Restful paths have been moved to api-reference/restful/[version]/[...slug].tsx
+    .filter(item => item.language !== ApiReferenceLanguageEnum.Restful);
+
+  let routers: ApiFileDateInfoType[] = [];
+  result.forEach(({ data }) => {
+    data.forEach(v => {
+      routers = routers.concat(v.contentList);
+    });
+  });
+
+  /**
+   * 1. /pymilvus/v2.4.x/DataImport/LocalBulkWriter/append_row.md
+   * 2. /pymilvus/v2.4.x/append_rows.md
+   */
+  const paths = routers.map(v => {
+    const {
+      frontMatter: { id, parentIds, category, version },
+    } = v;
+    const slug = [...parentIds, id];
+    return {
+      params: {
+        language: category,
+        version,
+        slug,
+      },
+    };
+  });
+
   return {
-    paths: [],
-    fallback: 'blocking',
+    paths: paths,
+    fallback: false,
   };
 };
 
 export const getStaticProps: GetStaticProps = async context => {
-  const { params } = context;
+  const { version } = context.params;
+  const languageCategory: ApiReferenceRouteEnum = context.params
+    .language as ApiReferenceRouteEnum;
 
-  if (
-    !params?.version ||
-    Array.isArray(params.version) ||
-    !params?.language ||
-    Array.isArray(params.language) ||
-    !params?.slug ||
-    !Array.isArray(params.slug)
-  ) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
-  const { version } = params;
-  const languageCategory: ApiReferenceRouteEnum =
-    params.language as ApiReferenceRouteEnum;
-
-  const slug = params.slug as string[];
+  const slug = context.params.slug as string[];
   const routeCategoryToLanguage: Record<
     ApiReferenceRouteEnum,
     ApiReferenceLanguageEnum
@@ -281,51 +312,28 @@ export const getStaticProps: GetStaticProps = async context => {
     [ApiReferenceRouteEnum.Restful]: ApiReferenceLanguageEnum.Restful,
   };
 
-  const apiLanguage = routeCategoryToLanguage[languageCategory];
-
-  if (!apiLanguage || apiLanguage === ApiReferenceLanguageEnum.Restful) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
   const apiData = generateApiReferenceVersionsInfo();
   const { versions, latestVersion } =
-    apiData.find(v => v.language === apiLanguage) || {};
-
-  if (!versions?.includes(version)) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
+    apiData.find(
+      v => v.language === routeCategoryToLanguage[languageCategory]
+    ) || {};
   const curCategoryData = generateApiMenuAndContentDataOfAllVersions({
-    language: apiLanguage,
+    language: routeCategoryToLanguage[languageCategory],
     withContent: true,
   });
 
   const { menuData, contentList: contentData } =
     curCategoryData.find(v => v.version === version) || {};
 
-  const targetContent = contentData?.find(v => {
-    const {
-      frontMatter: { id, parentIds },
-    } = v;
-    const targetSlug = slug.join('/');
-    const sourceSlug = [...parentIds, id].join('/');
-    return targetSlug === sourceSlug;
-  });
-
-  if (!targetContent) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
-  const { frontMatter, content: apiContent } = targetContent;
+  const { frontMatter, content: apiContent } =
+    contentData.find(v => {
+      const {
+        frontMatter: { id, parentIds },
+      } = v;
+      const targetSlug = slug.join('/');
+      const sourceSlug = [...parentIds, id].join('/');
+      return targetSlug === sourceSlug;
+    }) || {};
 
   const { tree: doc, codeList } = markdownToHtml(apiContent || '', {
     showAnchor: true,
@@ -338,7 +346,7 @@ export const getStaticProps: GetStaticProps = async context => {
 
   const curCategoryContentDataOfAllVersion =
     generateApiMenuAndContentDataOfAllVersions({
-      language: apiLanguage,
+      language: routeCategoryToLanguage[languageCategory],
       withContent: false,
     }).map(v => ({
       version: v.version,
@@ -371,6 +379,5 @@ export const getStaticProps: GetStaticProps = async context => {
         path: metaPath,
       },
     },
-    revalidate: 86400,
   };
 };

--- a/src/pages/api-reference/restful/[version]/[...slug].tsx
+++ b/src/pages/api-reference/restful/[version]/[...slug].tsx
@@ -8,6 +8,7 @@ import { ABSOLUTE_BASE_URL } from '@/consts';
 import LeftNavSection from '@/parts/docs/leftNavTree';
 import {
   AllMdVersionIdType,
+  ApiFileDateInfoType,
   ApiReferenceLanguageEnum,
   ApiReferenceMetaInfoEnum,
   ApiReferenceRouteEnum,
@@ -21,6 +22,7 @@ import {
 } from '@/utils/mdx';
 import {
   generateRestfulMenuAndContentDataOfAllVersions,
+  generateRestfulMenuAndContentDataOfSingleVersion,
   generateRestfulVersionsInfo,
   SPLIT_FLAG,
 } from '@/utils/restful';
@@ -154,38 +156,54 @@ export default function RestfulApiReference(props: {
 }
 
 export async function getStaticPaths() {
+  const restfulInfo = generateRestfulVersionsInfo();
+  const result = restfulInfo.map(data => {
+    const { language, versions } = data;
+    const ApiDataOfCurLang = versions.map(version =>
+      generateRestfulMenuAndContentDataOfSingleVersion({
+        version,
+        language,
+      })
+    );
+    return {
+      language,
+      versions,
+      data: ApiDataOfCurLang,
+    };
+  });
+
+  let routers: ApiFileDateInfoType[] = [];
+  result.forEach(({ data }) => {
+    data.forEach(v => {
+      routers = routers.concat(v.contentList);
+    });
+  });
+
+  const paths = routers.map(v => {
+    const {
+      frontMatter: { id, parentIds, version },
+    } = v;
+    const slug = [...parentIds, id.replace('.mdx', '.md')];
+    return {
+      params: {
+        version,
+        slug,
+      },
+    };
+  });
+
   return {
-    paths: [],
-    fallback: 'blocking',
+    paths,
+    fallback: false,
   };
 }
 
 export async function getStaticProps({ params }) {
-  if (
-    !params?.version ||
-    Array.isArray(params.version) ||
-    !params?.slug ||
-    !Array.isArray(params.slug)
-  ) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
   const { version, slug } = params;
   const restfulInfo = generateRestfulVersionsInfo();
   const { versions, latestVersion } =
     restfulInfo.find(v => v.language === ApiReferenceLanguageEnum.Restful) ||
     {};
-
-  if (!versions?.includes(version)) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
   const curCategoryData = generateRestfulMenuAndContentDataOfAllVersions({
     language: ApiReferenceLanguageEnum.Restful,
     withContent: true,
@@ -193,23 +211,15 @@ export async function getStaticProps({ params }) {
 
   const { menuData, contentList: contentData } =
     curCategoryData.find(v => v.version === version) || {};
-  const targetContent = contentData?.find(v => {
-    const {
-      frontMatter: { id, parentIds },
-    } = v;
-    const targetSlug = slug.join('/');
-    const sourceSlug = [...parentIds, id].join('/');
-    return targetSlug === sourceSlug;
-  });
-
-  if (!targetContent) {
-    return {
-      notFound: true,
-      revalidate: 60,
-    };
-  }
-
-  const { frontMatter, content } = targetContent;
+  const { frontMatter, content } =
+    contentData.find(v => {
+      const {
+        frontMatter: { id, parentIds },
+      } = v;
+      const targetSlug = slug.join('/');
+      const sourceSlug = [...parentIds, id].join('/');
+      return targetSlug === sourceSlug;
+    }) || {};
 
   const { exports } = await getVariablesFromMDX(content);
   const mdxSource = await serialize(content, {
@@ -263,6 +273,5 @@ export async function getStaticProps({ params }) {
         path: metaPath,
       },
     },
-    revalidate: 86400,
   };
 }


### PR DESCRIPTION
## Summary
- Revert the `fallback: blocking`/ISR changes for docs and API reference detail pages.
- Revert copying `src/docs` into runtime Docker images.
- Restore previous full static generation behavior for preview.

## Test plan
- [x] `git revert --no-commit -m 1 1abdf9c`
- [x] `git revert --no-commit 17de964`
- [x] `git diff --check`