### PR TITLE
fix: guard empty validKeys in RestSpace example renderers

### DIFF
--- a/src/components/mdx/rest-space/RestSpace.tsx
+++ b/src/components/mdx/rest-space/RestSpace.tsx
@@ -621,11 +621,18 @@ const ExampleResponses = ({
     return condition;
   });
 
-  const defaultValue = examples[validKeys[0]].summary.toUpperCase();
+  const defaultValue = examples[validKeys[0]]?.summary?.toUpperCase();
   const availableLabels = validKeys.map(key =>
     examples[key].summary.toUpperCase()
   );
   const [selected, setSelected] = useState(defaultValue);
+
+  // No example matches the current target/lang/response selection.
+  // Render nothing instead of dereferencing `undefined`, which would
+  // crash the whole static export (see Import (v2)/Create).
+  if (validKeys.length === 0) {
+    return null;
+  }
 
   if (!availableLabels.includes(selected)) {
     setSelected(availableLabels[0]);
@@ -714,11 +721,19 @@ const ExampleRequests = ({
       return condition;
     });
 
-    const defaultValue = examples[validKeys[0]].summary.toUpperCase();
+    const defaultValue = examples[validKeys[0]]?.summary?.toUpperCase();
     const availableLabels = validKeys.map(key =>
       examples[key].summary.toUpperCase()
     );
     const [selected, setSelected] = useState(defaultValue);
+
+    // No request example matches the current target/lang/request
+    // selection. Fall back to the bare curl command (same as the
+    // no-requestBody branch above) instead of dereferencing
+    // `undefined`, which would crash the whole static export.
+    if (validKeys.length === 0) {
+      return <CodeBlock className="language-bash" children={req} />;
+    }
 
     if (!availableLabels.includes(selected)) {
       setSelected(availableLabels[0]);


### PR DESCRIPTION
When no request/response example matches the current target/lang/ selection, `examples[validKeys[0]].summary` dereferenced `undefined` and threw "Cannot read properties of undefined (reading 'summary')". A single such API doc (e.g. v3.0.x Import (v2)/Create) crashed the entire Next.js static export and failed the CI build.

Use optional chaining for the default value and return a sensible fallback (null for responses, bare curl for requests) when validKeys is empty. The early return is placed after useState so React hook order stays stable.