### PR TITLE
fix: avoid on-demand doc render timeout from per-language frontmatter scan

### DIFF
--- a/src/components/localization/CreateDocDetailProps.ts
+++ b/src/components/localization/CreateDocDetailProps.ts
@@ -66,38 +66,6 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
     const { versions, latestVersion } = generateDocVersionInfo();
     const currentVersion = version || latestVersion;
 
-    const docMenu = generateMenuDataOfCurrentVersion({
-      docVersion: currentVersion,
-      lang,
-    });
-
-    // used to detect has same page of current md
-    const mdListData = generateAllContentDataOfAllVersion();
-
-    // languages that have this doc for hreflang tags
-    const availableLanguages = getAvailableLanguagesForDoc({
-      version: currentVersion,
-      docId: id,
-    });
-
-    // xxx.md of latest version
-    const outerApiMenuItem = generateApiMenuDataOfCurrentVersion({
-      docVersion: currentVersion,
-    });
-    const menu = [...docMenu, outerApiMenuItem];
-    const hreflangUrls = getDocHreflangUrls({
-      version: currentVersion,
-      latestVersion,
-      docId: id,
-      availableLanguages,
-    });
-    const canonicalUrl = getDocCanonicalUrl({
-      lang,
-      version: currentVersion,
-      latestVersion,
-      docId: id,
-    });
-
     const docDetailContentList = generateAllContentDataOfSingleVersion({
       version: currentVersion,
       withContent: true,
@@ -120,6 +88,42 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
       editPath,
       propsInfo,
     } = matchedDoc;
+
+    const docMenu = generateMenuDataOfCurrentVersion({
+      docVersion: currentVersion,
+      lang,
+    });
+
+    // used to detect has same page of current md
+    const mdListData = generateAllContentDataOfAllVersion();
+
+    // languages that have this doc for hreflang tags. Pass the matched file's
+    // relative path so this resolves via cheap existsSync checks instead of
+    // parsing every language's frontmatter on the on-demand render path.
+    const availableLanguages = getAvailableLanguagesForDoc({
+      version: currentVersion,
+      docId: id,
+      relativePath: editPath,
+      lang,
+    });
+
+    // xxx.md of latest version
+    const outerApiMenuItem = generateApiMenuDataOfCurrentVersion({
+      docVersion: currentVersion,
+    });
+    const menu = [...docMenu, outerApiMenuItem];
+    const hreflangUrls = getDocHreflangUrls({
+      version: currentVersion,
+      latestVersion,
+      docId: id,
+      availableLanguages,
+    });
+    const canonicalUrl = getDocCanonicalUrl({
+      lang,
+      version: currentVersion,
+      latestVersion,
+      docId: id,
+    });
 
     const { codeList, anchorList } = propsInfo;
     const headingContent = anchorList?.[0]?.label;

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -270,12 +270,33 @@ export const generateAllContentDataOfAllVersion = (lang?: LanguageEnum) => {
 export const getAvailableLanguagesForDoc = (params: {
   version: string;
   docId?: string;
+  // Relative path of the matched doc (e.g. "/v2.5.x/site/zh/userGuide/x.md")
+  // plus its language. Localized docs mirror the same file tree across
+  // languages, so when these are supplied we can check sibling files with
+  // existsSync instead of parsing every language's frontmatter — the latter is
+  // far too slow on the on-demand (blocking) render path.
+  relativePath?: string;
+  lang?: LanguageEnum;
 }): LanguageEnum[] => {
-  const { version, docId } = params;
+  const { version, docId, relativePath, lang } = params;
   const allLanguages = Object.values(LanguageEnum);
 
-  return allLanguages.filter(lang => {
-    const langDir = join(BASE_DOC_DIR, `localization/${version}/site/${lang}`);
+  if (docId && relativePath && lang) {
+    return allLanguages.filter(targetLang => {
+      const targetPath = join(
+        BASE_DOC_DIR,
+        'localization',
+        relativePath.replace(`/site/${lang}/`, `/site/${targetLang}/`)
+      );
+      return fs.existsSync(targetPath);
+    });
+  }
+
+  return allLanguages.filter(language => {
+    const langDir = join(
+      BASE_DOC_DIR,
+      `localization/${version}/site/${language}`
+    );
     if (!fs.existsSync(langDir)) {
       return false;
     }
@@ -286,7 +307,7 @@ export const getAvailableLanguagesForDoc = (params: {
     // Check if any file in this language dir has frontMatter.id === docId
     const data = generateAllContentDataOfSingleVersion({
       version,
-      lang,
+      lang: language,
       withContent: false,
     });
     return data.some(d => d.frontMatter.id === docId);


### PR DESCRIPTION
## Context
The on-demand docs/api-reference rendering feature is already on `preview` (commit 3cd34a55). This PR adds the missing fix on top of it.

## Problem
On-demand (non-English / archived) doc pages timed out (>30s, page never loads / 504) in the test environment. Root cause: `getAvailableLanguagesForDoc` parsed **every language's** frontmatter for the version on the request path (~4s per cold render on a dev box, far more on a constrained server), and this synchronous work blocks the Node event loop so concurrent cold requests pile up.

## Fix
- Resolve available languages via `fs.existsSync` on the mirrored localized file path (localized docs mirror the same file tree across languages) instead of parsing all frontmatter — drops the dominant cost from ~4s to <10ms.
- Reorder `getStaticProps` to match the requested doc first, then compute hreflang languages from its relative path.

Verified equivalent: 40 sample docs, 0 differences between the existsSync result and the previous frontmatter-id matching.

## Test plan
- [ ] On-demand page (e.g. `/docs/zh/v2.5.x/<id>`) loads quickly on first request (no 30s timeout)
- [ ] hreflang tags list the same languages as before
- [ ] Archived api-reference page renders
- [ ] Doc images still display (served from `public/docs/.../assets`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)