### PR TITLE
perf: read a single doc file on demand to bound runtime memory

### DIFF
--- a/src/components/localization/CreateDocDetailProps.ts
+++ b/src/components/localization/CreateDocDetailProps.ts
@@ -1,6 +1,7 @@
 import {
   generateDocVersionInfo,
   generateAllContentDataOfSingleVersion,
+  generateSingleDocContent,
   generateMenuDataOfCurrentVersion,
   generateAllContentDataOfAllVersion,
   getAvailableLanguagesForDoc,
@@ -66,15 +67,13 @@ export const createDocDetailProps = (lang: LanguageEnum, version = '') => {
     const { versions, latestVersion } = generateDocVersionInfo();
     const currentVersion = version || latestVersion;
 
-    const docDetailContentList = generateAllContentDataOfSingleVersion({
+    // Load only the requested doc instead of the whole version's content, so an
+    // on-demand render keeps runtime memory bounded.
+    const matchedDoc = generateSingleDocContent({
       version: currentVersion,
-      withContent: true,
       lang,
+      id,
     });
-
-    const matchedDoc = docDetailContentList.find(
-      v => v.frontMatter.id === id
-    );
 
     // Under the blocking fallback getStaticProps runs for arbitrary ids, so an
     // unknown id must 404 instead of throwing during destructuring.

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -232,6 +232,57 @@ export const generateContentDataOfSingleFile = (params: {
   return targetFileData;
 };
 
+// Reads only the requested doc's full content (and propsInfo) instead of loading
+// the entire version's content into memory. The frontmatter-only index (cached,
+// no content/propsInfo) resolves id -> file path, then a single file is read.
+// Used on the on-demand (blocking) render path to keep runtime memory bounded:
+// without this, every visited version/language would cache hundreds of docs'
+// full content in docCache, which can grow until the process is OOM-killed.
+export const generateSingleDocContent = (params: {
+  version: string;
+  lang?: LanguageEnum;
+  id: string;
+}) => {
+  const { version, lang = LanguageEnum.ENGLISH, id } = params;
+
+  const index = generateAllContentDataOfSingleVersion({
+    version,
+    lang,
+    withContent: false,
+  });
+  const meta = index.find(v => v.frontMatter.id === id);
+  if (!meta) {
+    return undefined;
+  }
+
+  // editPath is the version-relative path captured in readFile, e.g.
+  // "/v2.5.x/site/zh/userGuide/x.md"; it maps back under localization/.
+  const filePath = join(BASE_DOC_DIR, 'localization', meta.editPath);
+
+  try {
+    const fileData = fs.readFileSync(filePath, 'utf-8');
+    const { data, content } = matter(fileData) as {
+      data: DocFrontMatterType;
+      content: string;
+    };
+    const propsInfo = JSON.parse(
+      removeZeroWidthSpacesFromString(
+        fs.readFileSync(filePath.replace('.md', '.json'), 'utf-8')
+      )
+    );
+
+    return {
+      frontMatter: data,
+      content: removeZeroWidthSpacesFromString(content),
+      editPath: meta.editPath,
+      propsInfo,
+    };
+  } catch (error) {
+    console.error('generateSingleDocContent error:', error);
+    return undefined;
+  }
+};
+
 export const generateAllContentDataOfAllVersion = (lang?: LanguageEnum) => {
   const language = lang || LanguageEnum.ENGLISH;
   const cacheKey = `all-content-${language}`;


### PR DESCRIPTION
## Problem
On-demand doc rendering called `generateAllContentDataOfSingleVersion({ withContent: true })`, loading the **entire version's** content (hundreds of docs' markdown + propsInfo) into the module-level `docCache` just to render one page. Since the cache never evicts, memory grew with every visited version/language and could OOM the Node process — when that happens the whole upstream goes down and nginx returns 502 even for static pages (e.g. `/_next/data/.../bootcamp.json`).

## Fix
Add `generateSingleDocContent`: a cached **frontmatter-only** index (no content/propsInfo) resolves the doc id to its file path, then only that **one** file is read for content + propsInfo. The whole-version content cache is no longer populated on the render path, so runtime memory stays bounded.

## Verification
- Equivalence check on 50 sample docs: content, frontMatter and propsInfo identical to the previous whole-version load.
- Full `pnpm build` succeeds (5393 static pages, sitemap generated) — the prerendered English-latest pages exercise the same `getStaticProps` path.

## Notes
- Builds on top of #2333 (already in `preview`), which fixed the per-language frontmatter scan that caused the 30s timeouts. This PR addresses the complementary memory-growth risk.
- api-reference on-demand pages still load all versions of an SDK with content; the same single-file treatment can be applied there as a follow-up if needed.

## Test plan
- [ ] On-demand pages (e.g. `/docs/zh/v2.5.x/<id>`) render correctly
- [ ] Sustained traffic across many language/version combos no longer grows memory unbounded / no OOM-driven 502s
- [ ] hreflang, menu, version switcher and code blocks still work on doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)