### PR TITLE
perf: read a single api-reference file on demand to bound runtime memory

### DIFF
--- a/src/pages/api-reference/[language]/[version]/[...slug].tsx
+++ b/src/pages/api-reference/[language]/[version]/[...slug].tsx
@@ -10,6 +10,7 @@ import {
   generateApiMenuAndContentDataOfAllVersions,
   generateApiMenuAndContentDataOfSingleVersion,
   generateApiReferenceVersionsInfo,
+  generateSingleApiDocContent,
 } from '@/utils/apiReference';
 import {
   ApiFileDateInfoType,
@@ -334,18 +335,20 @@ export const getStaticProps: GetStaticProps = async context => {
     [ApiReferenceRouteEnum.Restful]: ApiReferenceLanguageEnum.Restful,
   };
 
+  const language = routeCategoryToLanguage[languageCategory];
   const apiData = generateApiReferenceVersionsInfo();
   const { versions, latestVersion } =
-    apiData.find(
-      v => v.language === routeCategoryToLanguage[languageCategory]
-    ) || {};
-  const curCategoryData = generateApiMenuAndContentDataOfAllVersions({
-    language: routeCategoryToLanguage[languageCategory],
-    withContent: true,
-  });
+    apiData.find(v => v.language === language) || {};
 
+  // Load only the requested version's menu + a frontmatter-only content index,
+  // then read the single matched file, so an on-demand render does not pull
+  // every version's content into memory.
   const { menuData, contentList: contentData } =
-    curCategoryData.find(v => v.version === version) || {};
+    generateApiMenuAndContentDataOfSingleVersion({
+      language,
+      version: version as string,
+      withContent: false,
+    }) as any;
 
   // Under the blocking fallback getStaticProps runs for arbitrary params, so an
   // unknown version/slug must 404 instead of throwing during destructuring.
@@ -353,19 +356,24 @@ export const getStaticProps: GetStaticProps = async context => {
     return { notFound: true };
   }
 
-  const { frontMatter, content: apiContent } =
-    contentData.find(v => {
-      const {
-        frontMatter: { id, parentIds },
-      } = v;
-      const targetSlug = slug.join('/');
-      const sourceSlug = [...parentIds, id].join('/');
-      return targetSlug === sourceSlug;
-    }) || {};
+  const matchedDoc = contentData.find(v => {
+    const {
+      frontMatter: { id, parentIds },
+    } = v;
+    const targetSlug = slug.join('/');
+    const sourceSlug = [...parentIds, id].join('/');
+    return targetSlug === sourceSlug;
+  });
 
-  if (!frontMatter) {
+  if (!matchedDoc) {
     return { notFound: true };
   }
+
+  const { frontMatter } = matchedDoc;
+  const apiContent = generateSingleApiDocContent({
+    language,
+    relativePath: frontMatter.relativePath,
+  });
 
   const { tree: doc, codeList } = markdownToHtml(apiContent || '', {
     showAnchor: true,

--- a/src/pages/api-reference/restful/[version]/[...slug].tsx
+++ b/src/pages/api-reference/restful/[version]/[...slug].tsx
@@ -24,6 +24,7 @@ import {
   generateRestfulMenuAndContentDataOfAllVersions,
   generateRestfulMenuAndContentDataOfSingleVersion,
   generateRestfulVersionsInfo,
+  generateSingleRestfulDocContent,
   SPLIT_FLAG,
 } from '@/utils/restful';
 import { writeSitemapSegment } from '@/utils/doc-sitemap-segments';
@@ -225,13 +226,15 @@ export async function getStaticProps({ params }) {
   const { versions, latestVersion } =
     restfulInfo.find(v => v.language === ApiReferenceLanguageEnum.Restful) ||
     {};
-  const curCategoryData = generateRestfulMenuAndContentDataOfAllVersions({
-    language: ApiReferenceLanguageEnum.Restful,
-    withContent: true,
-  });
-
+  // Load only the requested version's menu + a frontmatter-only content index,
+  // then read the single matched .mdx file, so an on-demand render does not pull
+  // every version's content into memory.
   const { menuData, contentList: contentData } =
-    curCategoryData.find(v => v.version === version) || {};
+    generateRestfulMenuAndContentDataOfSingleVersion({
+      language: ApiReferenceLanguageEnum.Restful,
+      version,
+      withContent: false,
+    }) as any;
 
   // Under the blocking fallback getStaticProps runs for arbitrary params, so an
   // unknown version/slug must 404 instead of throwing during destructuring.
@@ -239,19 +242,24 @@ export async function getStaticProps({ params }) {
     return { notFound: true };
   }
 
-  const { frontMatter, content } =
-    contentData.find(v => {
-      const {
-        frontMatter: { id, parentIds },
-      } = v;
-      const targetSlug = slug.join('/');
-      const sourceSlug = [...parentIds, id].join('/');
-      return targetSlug === sourceSlug;
-    }) || {};
+  const matchedDoc = contentData.find(v => {
+    const {
+      frontMatter: { id, parentIds },
+    } = v;
+    const targetSlug = slug.join('/');
+    const sourceSlug = [...parentIds, id].join('/');
+    return targetSlug === sourceSlug;
+  });
 
-  if (!frontMatter) {
+  if (!matchedDoc) {
     return { notFound: true };
   }
+
+  const { frontMatter } = matchedDoc;
+  const content = generateSingleRestfulDocContent({
+    language: ApiReferenceLanguageEnum.Restful,
+    relativePath: frontMatter.relativePath,
+  });
 
   const { exports } = await getVariablesFromMDX(content);
   const mdxSource = await serialize(content, {

--- a/src/utils/apiReference.ts
+++ b/src/utils/apiReference.ts
@@ -297,6 +297,27 @@ export const generateApiMenuAndContentDataOfSingleVersion = (params: {
   return result;
 };
 
+// Reads only the requested api doc's raw content instead of loading every
+// version's content into memory. The single-version menu/index (withContent
+// false) resolves the slug to a file's relativePath; this reads that one file.
+// Used on the on-demand render path to keep runtime memory bounded.
+export const generateSingleApiDocContent = (params: {
+  language: ApiReferenceLanguageEnum;
+  relativePath: string;
+}): string => {
+  const base = API_REFERENCE_CONFIG[params.language].path;
+  const filePath = join(base, params.relativePath);
+
+  try {
+    const fileData = fs.readFileSync(filePath, 'utf-8');
+    const { content } = matter(fileData) as { content: string };
+    return content;
+  } catch (error) {
+    console.error('generateSingleApiDocContent error:', error);
+    return '';
+  }
+};
+
 // 4. file data list of each language for all versions to generate dynamic routes
 export const generateApiMenuAndContentDataOfAllVersions = (params: {
   language: ApiReferenceLanguageEnum;

--- a/src/utils/restful.ts
+++ b/src/utils/restful.ts
@@ -190,6 +190,26 @@ const generateApiMenuData = (params: {
   }
 };
 
+// Reads only the requested restful doc's raw content instead of loading every
+// version's content into memory. relativePath points at the actual .mdx file.
+// Used on the on-demand render path to keep runtime memory bounded.
+export const generateSingleRestfulDocContent = (params: {
+  language: ApiReferenceLanguageEnum;
+  relativePath: string;
+}): string => {
+  const base = API_RESTFUL_CONFIG[params.language].path;
+  const filePath = join(base, params.relativePath);
+
+  try {
+    const fileData = fs.readFileSync(filePath, 'utf-8');
+    const { content } = matter(fileData) as { content: string };
+    return content;
+  } catch (error) {
+    console.error('generateSingleRestfulDocContent error:', error);
+    return '';
+  }
+};
+
 export const generateRestfulMenuAndContentDataOfSingleVersion = (params: {
   language: ApiReferenceLanguageEnum;
   version: string;


### PR DESCRIPTION
## Problem
The SDK (`[language]/[version]/[...slug]`) and RESTful api-reference routes called `generate*MenuAndContentDataOfAllVersions({ withContent: true })`, loading **every version's** content into the module cache just to render one page. On the on-demand (blocking) render path this grows memory with each visited version and risks OOM-killing the Node process (which 502s the whole site, including static pages).

## Fix
Mirror the docs single-file change (already in `preview`, #2334):
- Add `generateSingleApiDocContent` / `generateSingleRestfulDocContent`.
- Load only the requested version's menu + a **frontmatter-only** content index to resolve the slug to a file path, then read that **one** file's content (SDK: markdown; RESTful: the `.mdx`).
- The all-versions frontmatter list (version switcher) stays — it carries no content.

## Verification
- Full `pnpm build` succeeds (5393 static pages, sitemap generated); prerendered latest api versions exercise the same `getStaticProps` path.

## Test plan
- [ ] On-demand archived api page renders (e.g. `/api-reference/pymilvus/v2.4.x/<...>` and a RESTful archived page)
- [ ] Menu, version switcher, code blocks still work
- [ ] Sustained traffic across many SDK/version combos no longer grows memory unbounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)