### PR TITLE
feat: temporarily hide learn-milvus/tradeoff page

### DIFF
--- a/src/components/learn-milvus/components/TradeoffChart.tsx
+++ b/src/components/learn-milvus/components/TradeoffChart.tsx
@@ -42,11 +42,13 @@ export default function TradeoffChart({
       ...idx,
       qps: idx.perScale[scale].qps,
       recall: idx.perScale[scale].recall,
-      memoryMB: idx.perScale[scale].memoryMB,
+      buildSec: idx.perScale[scale].buildSec,
     }));
 
-    const minQps = Math.max(0.1, d3.min(data, (d) => d.qps)!);
-    const maxQps = d3.max(data, (d) => d.qps)!;
+    // Robust against placeholder/zero data (log scale needs positive domain).
+    const positiveQps = data.map((d) => d.qps).filter((q) => q > 0);
+    const minQps = positiveQps.length ? Math.max(0.1, d3.min(positiveQps)!) : 0.1;
+    const maxQps = positiveQps.length ? d3.max(positiveQps)! : 10000;
 
     const x = d3
       .scaleLog()
@@ -58,12 +60,13 @@ export default function TradeoffChart({
       .domain([0.7, 1.02])
       .range([M.top + innerH, M.top]);
 
-    const maxMem = d3.max(data, (d) => d.memoryMB)!;
-    const minMem = d3.min(data, (d) => d.memoryMB)!;
-    const r = d3
-      .scaleSqrt()
-      .domain([minMem, maxMem])
-      .range([22, 10]);
+    // Bubble size encodes build time — larger bubble = longer to build.
+    const maxBuild = d3.max(data, (d) => d.buildSec)!;
+    const minBuild = d3.min(data, (d) => d.buildSec)!;
+    const r =
+      maxBuild === minBuild
+        ? () => 14
+        : d3.scaleSqrt().domain([minBuild, maxBuild]).range([10, 24]);
 
     // Grid lines
     const recallTicks = [0.7, 0.8, 0.9, 1.0];
@@ -142,13 +145,13 @@ export default function TradeoffChart({
       .text('\u2197 better');
 
     // Bubbles
-    const sortedData = [...data].sort((a, b) => r(b.memoryMB) - r(a.memoryMB));
+    const sortedData = [...data].sort((a, b) => r(b.buildSec) - r(a.buildSec));
     sortedData.forEach((d) => {
       const isHighlighted = highlight === d.id;
       const isFaded = highlight !== null && !isHighlighted;
       const cx = x(d.qps);
       const cy = y(d.recall);
-      const radius = r(d.memoryMB);
+      const radius = r(d.buildSec);
 
       svg
         .append('circle')

--- a/src/components/learn-milvus/data/indexBenchmarks.ts
+++ b/src/components/learn-milvus/data/indexBenchmarks.ts
@@ -1,3 +1,16 @@
+// ⚠️ PLACEHOLDER DATA — DO NOT TRUST THESE NUMBERS.
+// Every qps / recall / buildSec below is a placeholder pending real
+// VectorDBBench runs (Cohere 768d, k=10). Replace each value with the
+// measured result.
+//
+// What to fill per (index, scale):
+//   qps      → peak QPS from the concurrent search phase
+//   recall   → Recall@10 from the serial search phase (run with --k 10), 0~1
+//   buildSec → index build/optimize duration in seconds (NOT load duration)
+//
+// Memory was intentionally removed: VectorDBBench's memory metric is
+// unreliable for self-hosted Milvus, so the page no longer shows it.
+
 export type IndexId =
   | 'FLAT'
   | 'IVF_FLAT'
@@ -6,12 +19,11 @@ export type IndexId =
   | 'HNSW'
   | 'DISKANN';
 
-export type Scale = '1K' | '100K' | '10M';
+export type Scale = '100K' | '1M' | '10M';
 
 export type IndexBenchmark = {
   qps: number;
   recall: number;
-  memoryMB: number;
   buildSec: number;
 };
 
@@ -26,23 +38,24 @@ export type IndexInfo = {
 };
 
 export const SCALES: { id: Scale; label: string; size: number }[] = [
-  { id: '1K', label: '1K vectors', size: 1_000 },
   { id: '100K', label: '100K vectors', size: 100_000 },
+  { id: '1M', label: '1M vectors', size: 1_000_000 },
   { id: '10M', label: '10M vectors', size: 10_000_000 },
 ];
 
+// TODO(benchmark): replace all perScale numbers with VectorDBBench results.
 export const INDEXES: IndexInfo[] = [
   {
     id: 'FLAT',
     name: 'FLAT',
-    tagline: 'Brute force \u2014 compare against every vector.',
+    tagline: 'Brute force — compare against every vector.',
     color: '#94a3b8',
     bestFor: 'Tiny datasets or "ground truth" baselines.',
-    worstFor: 'Anything large \u2014 speed scales linearly with N.',
+    worstFor: 'Anything large — speed scales linearly with N.',
     perScale: {
-      '1K': { qps: 5000, recall: 1.0, memoryMB: 3, buildSec: 0 },
-      '100K': { qps: 50, recall: 1.0, memoryMB: 300, buildSec: 0 },
-      '10M': { qps: 0.5, recall: 1.0, memoryMB: 30000, buildSec: 0 },
+      '100K': { qps: 0, recall: 1.0, buildSec: 0 },
+      '1M': { qps: 0, recall: 1.0, buildSec: 0 },
+      '10M': { qps: 0, recall: 1.0, buildSec: 0 },
     },
   },
   {
@@ -51,37 +64,38 @@ export const INDEXES: IndexInfo[] = [
     tagline: 'Cluster the data; search only the nearest clusters.',
     color: '#4dabf7',
     bestFor: 'Medium datasets where you want exact distances within clusters.',
-    worstFor: 'Very high recall on large data \u2014 you must scan many clusters.',
+    worstFor: 'Very high recall on large data — you must scan many clusters.',
     perScale: {
-      '1K': { qps: 8000, recall: 0.99, memoryMB: 4, buildSec: 0.1 },
-      '100K': { qps: 800, recall: 0.95, memoryMB: 320, buildSec: 5 },
-      '10M': { qps: 50, recall: 0.92, memoryMB: 32000, buildSec: 600 },
+      '100K': { qps: 0, recall: 0, buildSec: 0 },
+      '1M': { qps: 0, recall: 0, buildSec: 0 },
+      '10M': { qps: 0, recall: 0, buildSec: 0 },
     },
   },
   {
     id: 'IVF_SQ8',
     name: 'IVF_SQ8',
-    tagline: 'IVF + 8-bit scalar quantization. ~4\u00d7 less memory.',
+    tagline: 'IVF + 8-bit scalar quantization. ~4× less memory.',
     color: '#69db7c',
     bestFor: 'When IVF_FLAT does not fit in memory.',
-    worstFor: 'When you need maximum recall \u2014 quantization adds noise.',
+    worstFor: 'When you need maximum recall — quantization adds noise.',
     perScale: {
-      '1K': { qps: 9000, recall: 0.97, memoryMB: 2, buildSec: 0.2 },
-      '100K': { qps: 1200, recall: 0.93, memoryMB: 80, buildSec: 8 },
-      '10M': { qps: 100, recall: 0.89, memoryMB: 8000, buildSec: 900 },
+      '100K': { qps: 0, recall: 0, buildSec: 0 },
+      '1M': { qps: 0, recall: 0, buildSec: 0 },
+      '10M': { qps: 0, recall: 0, buildSec: 0 },
     },
   },
   {
     id: 'IVF_PQ',
     name: 'IVF_PQ',
-    tagline: 'IVF + product quantization. Aggressive compression, ~16\u00d7 smaller.',
+    tagline: 'IVF + product quantization. Aggressive compression, ~16× smaller.',
     color: '#ffd43b',
     bestFor: 'Huge datasets where memory is the bottleneck.',
     worstFor: 'Latency-critical or high-recall workloads.',
+    // NOTE: IVF_PQ has no CPU CLI command in VectorDBBench — run it via the Web UI (init_bench).
     perScale: {
-      '1K': { qps: 10000, recall: 0.85, memoryMB: 1, buildSec: 0.5 },
-      '100K': { qps: 3000, recall: 0.8, memoryMB: 25, buildSec: 15 },
-      '10M': { qps: 800, recall: 0.75, memoryMB: 2500, buildSec: 1800 },
+      '100K': { qps: 0, recall: 0, buildSec: 0 },
+      '1M': { qps: 0, recall: 0, buildSec: 0 },
+      '10M': { qps: 0, recall: 0, buildSec: 0 },
     },
   },
   {
@@ -90,11 +104,11 @@ export const INDEXES: IndexInfo[] = [
     tagline: 'Hierarchical graph. Best speed-recall trade-off in memory.',
     color: '#da77f2',
     bestFor: 'Latency-critical search with high recall and ample RAM.',
-    worstFor: 'Memory-constrained environments \u2014 uses ~1.5\u20132\u00d7 the raw data.',
+    worstFor: 'Memory-constrained environments — uses ~1.5–2× the raw data.',
     perScale: {
-      '1K': { qps: 12000, recall: 0.99, memoryMB: 6, buildSec: 0.3 },
-      '100K': { qps: 5000, recall: 0.98, memoryMB: 600, buildSec: 30 },
-      '10M': { qps: 1500, recall: 0.95, memoryMB: 60000, buildSec: 7200 },
+      '100K': { qps: 0, recall: 0, buildSec: 0 },
+      '1M': { qps: 0, recall: 0, buildSec: 0 },
+      '10M': { qps: 0, recall: 0, buildSec: 0 },
     },
   },
   {
@@ -103,11 +117,11 @@ export const INDEXES: IndexInfo[] = [
     tagline: 'Graph index that lives on disk. Trades latency for memory.',
     color: '#ff8787',
     bestFor: 'Billion-scale datasets that cannot fit in RAM.',
-    worstFor: 'Small datasets \u2014 disk I/O overhead outweighs benefits.',
+    worstFor: 'Small datasets — disk I/O overhead outweighs benefits.',
     perScale: {
-      '1K': { qps: 2000, recall: 0.97, memoryMB: 4, buildSec: 1 },
-      '100K': { qps: 1500, recall: 0.96, memoryMB: 80, buildSec: 60 },
-      '10M': { qps: 800, recall: 0.93, memoryMB: 8000, buildSec: 14400 },
+      '100K': { qps: 0, recall: 0, buildSec: 0 },
+      '1M': { qps: 0, recall: 0, buildSec: 0 },
+      '10M': { qps: 0, recall: 0, buildSec: 0 },
     },
   },
 ];

--- a/src/i18n/en/learnMilvus.json
+++ b/src/i18n/en/learnMilvus.json
@@ -162,7 +162,7 @@
     "subtitle": "There is no single \"best\" index. The right choice depends on your data size, latency budget, recall target, and memory constraints. Pick a dataset scale and hover the bubbles or cards to compare.",
     "datasetScale": "Dataset scale",
     "speedVsRecall": "Speed vs. Recall",
-    "bubbleSizeNote": "Bubble size shows memory footprint — <strong>smaller bubble = more memory used</strong>.",
+    "bubbleSizeNote": "Bubble size shows index build time — <strong>larger bubble = slower to build</strong>.",
     "speedLabel": "Speed",
     "memoryLabel": "Memory",
     "buildLabel": "Build",

--- a/src/pages/learn-milvus/index.tsx
+++ b/src/pages/learn-milvus/index.tsx
@@ -14,7 +14,8 @@ export default function LearnMilvusHome() {
     { to: '/learn-milvus/ivf', title: t('home.cards.ivf.title'), desc: t('home.cards.ivf.desc') },
     { to: '/learn-milvus/hnsw', title: t('home.cards.hnsw.title'), desc: t('home.cards.hnsw.desc') },
     { to: '/learn-milvus/diskann', title: t('home.cards.diskann.title'), desc: t('home.cards.diskann.desc') },
-    { to: '/learn-milvus/tradeoff', title: t('home.cards.tradeoff.title'), desc: t('home.cards.tradeoff.desc') },
+    // Temporarily hidden: tradeoff page
+    // { to: '/learn-milvus/tradeoff', title: t('home.cards.tradeoff.title'), desc: t('home.cards.tradeoff.desc') },
   ];
 
   return (

--- a/src/pages/learn-milvus/tradeoff.tsx
+++ b/src/pages/learn-milvus/tradeoff.tsx
@@ -9,11 +9,6 @@ import type { Scale } from '@/components/learn-milvus/data/indexBenchmarks';
 import TradeoffChart from '@/components/learn-milvus/components/TradeoffChart';
 import styles from '@/components/learn-milvus/learnMilvus.module.css';
 
-function formatMemory(mb: number): string {
-  if (mb >= 1000) return `${(mb / 1000).toFixed(1)} GB`;
-  return `${mb} MB`;
-}
-
 function formatBuild(sec: number): string {
   if (sec === 0) return 'instant';
   if (sec < 60) return `${sec}s`;
@@ -25,6 +20,11 @@ function formatQps(qps: number): string {
   if (qps >= 1000) return `${(qps / 1000).toFixed(1)}k`;
   if (qps >= 10) return `${Math.round(qps)}`;
   return qps.toFixed(1);
+}
+
+// Temporarily hidden: remove getStaticProps below to restore this page
+export function getStaticProps() {
+  return { notFound: true };
 }
 
 export default function TradeoffDashboard() {
@@ -113,10 +113,6 @@ export default function TradeoffDashboard() {
                   <div className={styles.metric}>
                     <div className={styles.metricLabelSmall}>Recall@10</div>
                     <div className={styles.metricValueSmall}>{(b.recall * 100).toFixed(0)}%</div>
-                  </div>
-                  <div className={styles.metric}>
-                    <div className={styles.metricLabelSmall}>{t('tradeoff.memoryLabel')}</div>
-                    <div className={styles.metricValueSmall}>{formatMemory(b.memoryMB)}</div>
                   </div>
                   <div className={styles.metric}>
                     <div className={styles.metricLabelSmall}>{t('tradeoff.buildLabel')}</div>


### PR DESCRIPTION
## Summary
- Temporarily hide the `/learn-milvus/tradeoff` page:
  - Comment out its entry card on the learn-milvus home page
  - Return 404 via `getStaticProps({ notFound: true })` — page code is kept intact; remove both to restore
- Replace estimated benchmark numbers with placeholders pending real VectorDBBench runs; drop the unreliable memory metric and switch bubble size to encode build time

## Before restoring the page
1. Fill in real VectorDBBench results in `indexBenchmarks.ts` (current all-zero qps placeholders produce NaN coordinates on the log-scale chart)
2. Sync the updated `bubbleSizeNote` copy to non-English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)