### PR TITLE
fix(seo): route v3 bare-category API redirects to Java v2 (Go has no v3.0.x)

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -455,11 +455,15 @@ server {
     # /v3.x/site/{otherlang}/.../{file} → /docs/{file} (fallback to English latest)
     rewrite ^/v[3-9]\.\d+\.x/site/[^/]+/(.+/)?([^/]+)$ /docs/$2 permanent;
 
-    # v3+ API source-repo paths → api-reference (version preserved; already live)
+    # v3+ API source-repo paths → api-reference. Version is preserved per SDK.
+    # NOTE: unlike docs, api-reference is always versioned, and the version set
+    # differs per SDK — pymilvus/java/node/restful publish v3.0.x but Go does
+    # NOT (its latest is v2.6.x). So a /v3.x/{bare-category}/ path cannot be Go;
+    # those top-level categories are the Java v2 client API and route there.
     rewrite ^/(v[3-9]\.\d+\.x)/(v[12]/.*)$ /api-reference/java/$1/$2 permanent;
     rewrite ^/(v[3-9]\.\d+\.x)/(Collection|Partition|Role|Utility|Misc|BulkWriter)(/.*)?$ /api-reference/java/$1/v1/$2$3 permanent;
     rewrite ^/(v[3-9]\.\d+\.x)/(ORM|MilvusClient|DataImport|EmbeddingModels|Rerankers)(/.*)?$ /api-reference/pymilvus/$1/$2$3 permanent;
-    rewrite ^/(v[3-9]\.\d+\.x)/(Management|Collections|Vector|Client|Authentication|Partitions|ResourceGroup|Database|Volume|Data|Index|Schema|SearchResult|User|Connections|Alias)(/.*)?$ /api-reference/go/$1/$2$3 permanent;
+    rewrite ^/(v[3-9]\.\d+\.x)/(Management|Collections|Vector|Client|Authentication|Partitions|ResourceGroup|Database|Volume|Data|Index|Schema|SearchResult|User|Connections|Alias)(/.*)?$ /api-reference/java/$1/v2/$2$3 permanent;
 
     expires -1; # Set it to different value depending on your standard requirements
   }


### PR DESCRIPTION
## 背景

修复已合入 `preview` 的 PR #2342 中一个 nginx 重定向 bug（v3 source-repo 路径 → api-reference）。

## 问题

api-reference 的版本是**按 SDK 独立**的，版本集不一致：pymilvus / java / node / restful 有 v3.0.x，但 **Go 没有**（最新仍是 v2.6.x）。

PR #2342 的 v3 规则把裸类目（`Management` / `Authentication` / `ResourceGroup` / …）重定向到 `/api-reference/go/v3.0.x/…`，而 Go 没有 v3.0.x → **目标 500**（比原来的 404 更糟）。

## 修复

`/v3.x/{裸类目}/…` 不可能是 Go（Go 无 v3.0.x），这些顶层类目就是 **Java v2 客户端 API**，改投 `/api-reference/java/$1/v2/…`。

## 验证（对真实 404 数据集实测）

- 受影响的 35 条原本全部 **500**；改投后 **19 条 → 200**，其余 → 404（这些方法在 v3 已删除，无正确目标）。
- 全量 API 源码路径抽测 70 个目标：**62 → 200，8 → 404，零 500**。
- 其它 SDK 规则（pymilvus 49、java v1/v2 显式子目录 262）不受影响，仍全 200。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
