### PR TITLE
fix(seo): make C# api-reference (v2.2.x) reachable again

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -425,7 +425,13 @@ server {
     rewrite ^/office-hour /blog/join-milvus-office-hours-to-get-support-from-vectordb-experts.md permanent;
 
     rewrite ^/docs/v2\.[0-3]\.x /docs permanent;
-    rewrite ^/api-reference/(pymilvus|java|go|node|csharp|restful)/v2\.[0-3]\.x /docs permanent;
+    # csharp is intentionally excluded: its only api-reference version is v2.2.x,
+    # which must stay reachable (see CSHARP_DOCS_MINIMUM_VERSION). Other csharp
+    # versions don't exist and are routed to v2.2.x just below.
+    rewrite ^/api-reference/(pymilvus|java|go|node|restful)/v2\.[0-3]\.x /docs permanent;
+    # C# only ships v2.2.x; send any other (non-existent) version to it to avoid 500.
+    rewrite ^/api-reference/csharp/(?!v2\.2\.x)[^/]+/(.+)$ /api-reference/csharp/v2.2.x/$1 permanent;
+    rewrite ^/api-reference/csharp/(?!v2\.2\.x)[^/]*/?$ /api-reference/csharp/v2.2.x/About.md permanent;
 
     # Redirect source-repo paths missing /docs/ prefix
     # /v2.x.x/site/en/.../{file} → /docs/v2.x.x/{file}

--- a/src/utils/apiReference.ts
+++ b/src/utils/apiReference.ts
@@ -14,6 +14,7 @@ import {
   DOCS_MINIMUM_VERSION,
   sortVersionDir,
   CPP_DOCS_MINIMUM_VERSION,
+  CSHARP_DOCS_MINIMUM_VERSION,
 } from './docs';
 import { getCacheData, setCacheData } from './index';
 
@@ -203,7 +204,7 @@ const API_REFERENCE_CONFIG = {
   [ApiReferenceLanguageEnum.Csharp]: {
     name: ApiReferenceLabelEnum.Csharp,
     path: `${BASE_DOC_DIR}/API_Reference/${ApiReferenceLanguageEnum.Csharp}`,
-    minVersion: DOCS_MINIMUM_VERSION,
+    minVersion: CSHARP_DOCS_MINIMUM_VERSION,
     category: ApiReferenceRouteEnum.Csharp,
   },
 };

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -17,6 +17,10 @@ const matter = require('gray-matter');
 export const BASE_DOC_DIR = join(process.cwd(), 'src/docs');
 export const DOCS_MINIMUM_VERSION = 'v2.4.x';
 export const CPP_DOCS_MINIMUM_VERSION = 'v2.6.x';
+// The C# SDK api-reference only ships v2.2.x, which is below the default
+// minimum (v2.4.x). Without its own floor it would be filtered out entirely
+// and the route 500s on the missing version dir.
+export const CSHARP_DOCS_MINIMUM_VERSION = 'v2.2.x';
 const IGNORE_VERSIONS = ['v2.3.0-beta'];
 export const IGNORE_FILES = [
   'README.md',


### PR DESCRIPTION
## 问题

线上 C# api-reference 全部 **500**（如 `/api-reference/csharp/v2.6.x/About.md`），无法访问。

## 根因（不是 nginx，是版本过滤）

api-reference 读取版本时有一个最低版本过滤 `versionNum >= minVersion`。C# SDK 在内容仓库里**只有 v2.2.x 一个版本**，而 csharp 用的是默认 `DOCS_MINIMUM_VERSION = 'v2.4.x'`：

- `v2.2.x < v2.4.x` → C# 被过滤掉 → **0 个可用版本** → 不进 build、按需渲染时 `fs.statSync` 撞上不存在的版本目录 → **500**。
- 雪上加霜：C# 唯一的 v2.2.x 还被 `api-reference/.../v2.[0-3].x → /docs` 这条"老版本下线"规则重定向走。

## 修复（照搬已有的 C++ 范式）

C++ 同样只有老版本，代码里早已用单独的 `CPP_DOCS_MINIMUM_VERSION` 处理。给 C# 同样的待遇：

1. **代码**：新增 `CSHARP_DOCS_MINIMUM_VERSION = 'v2.2.x'`，把 C# 的 `minVersion` 换成它（`apiReference.ts`）——让它唯一的版本通过过滤。
2. **nginx**：把 `csharp` 从 v2.0–2.3 下线规则里摘除（让 v2.2.x 不被重定向走）；其它不存在的 csharp 版本统一收口到 v2.2.x，避免 500。

效果：`/api-reference/csharp/v2.2.x/...` 恢复 200。其它 SDK 不受影响。

## 注意

C# 文档在内容仓库里就停在 v2.2.x（约 2022 年，已停更），所以对外展示的是 v2.2.x。若要更新的 C# 文档，需在 web-content 仓库补新版本（不在本 PR 范围）。

## 验证

构建部署后请抽查 `/api-reference/csharp/v2.2.x/About.md` 返回 200，且其它 SDK（pymilvus/java/go/node/restful）不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
