### PR TITLE
feat(seo): centralize JSON-LD in a schema factory and expand coverage

### DIFF
--- a/src/components/JsonLd/index.tsx
+++ b/src/components/JsonLd/index.tsx
@@ -1,0 +1,38 @@
+import Head from 'next/head';
+import type { SchemaObject } from '@/schema/generators';
+
+interface JsonLdProps {
+  /** One schema object or several (e.g. Article + BreadcrumbList). */
+  schema: SchemaObject | (SchemaObject | null | undefined)[];
+}
+
+/**
+ * Renders one or more JSON-LD `<script>` tags into the document head.
+ * Each object is serialized with JSON.stringify (never hand-built strings)
+ * and gets a stable key so Next.js's <Head> de-dupes correctly across pages.
+ */
+export default function JsonLd({ schema }: JsonLdProps) {
+  const items = (Array.isArray(schema) ? schema : [schema]).filter(
+    (obj): obj is SchemaObject => Boolean(obj)
+  );
+
+  if (!items.length) return null;
+
+  return (
+    <Head>
+      {items.map((obj, index) => {
+        const type = Array.isArray(obj['@type'])
+          ? obj['@type'].join('-')
+          : obj['@type'];
+        const key = `ld-${type || 'schema'}-${obj['@id'] || index}`;
+        return (
+          <script
+            key={key}
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(obj) }}
+          />
+        );
+      })}
+    </Head>
+  );
+}

--- a/src/components/learn-milvus/components/LearnMilvusSeo.tsx
+++ b/src/components/learn-milvus/components/LearnMilvusSeo.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { ABSOLUTE_BASE_URL } from '@/consts';
+import { buildSchema } from '@/schema';
 
 export interface FaqItem {
   question: string;
@@ -32,11 +33,11 @@ export default function LearnMilvusSeo(props: LearnMilvusSeoProps) {
     : undefined;
 
   const breadcrumbItems = [
-    { name: 'Home', item: ABSOLUTE_BASE_URL },
-    { name: 'Learn Milvus', item: `${ABSOLUTE_BASE_URL}${LEARN_MILVUS_PATH}` },
+    { name: 'Home', url: ABSOLUTE_BASE_URL },
+    { name: 'Learn Milvus', url: `${ABSOLUTE_BASE_URL}${LEARN_MILVUS_PATH}` },
   ];
   if (path !== LEARN_MILVUS_PATH && breadcrumbName) {
-    breadcrumbItems.push({ name: breadcrumbName, item: url });
+    breadcrumbItems.push({ name: breadcrumbName, url });
   }
 
   const learningResourceLd = {
@@ -59,30 +60,16 @@ export default function LearnMilvusSeo(props: LearnMilvusSeoProps) {
     },
   };
 
-  const breadcrumbLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: breadcrumbItems.map((entry, index) => ({
-      '@type': 'ListItem',
-      position: index + 1,
-      name: entry.name,
-      item: entry.item,
-    })),
-  };
+  const breadcrumbLd = buildSchema('breadcrumb', breadcrumbItems);
 
   const faqLd = faq?.length
-    ? {
-        '@context': 'https://schema.org',
-        '@type': 'FAQPage',
-        mainEntity: faq.map(item => ({
-          '@type': 'Question',
-          name: item.question,
-          acceptedAnswer: {
-            '@type': 'Answer',
-            text: item.answer,
-          },
+    ? buildSchema('faq', {
+        absoluteUrl: url,
+        faqItems: faq.map(item => ({
+          question: item.question,
+          answerPlainText: item.answer,
         })),
-      }
+      })
     : null;
 
   return (

--- a/src/components/localization/BlogDetail.tsx
+++ b/src/components/localization/BlogDetail.tsx
@@ -12,6 +12,8 @@ import clsx from 'clsx';
 import BlogAnchorSection from '@/parts/blogs/blogAnchors';
 import pageClasses from '@/styles/responsive.module.css';
 import { ABSOLUTE_BASE_URL, MILVUS_RAW_BLOGS_BASE_URL } from '@/consts';
+import JsonLd from '@/components/JsonLd';
+import { buildSchema } from '@/schema';
 import { useCopyCode } from '@/hooks/enhanceCodeBlock';
 import 'highlight.js/styles/atom-one-dark.css';
 import { useEffect } from 'react';
@@ -137,11 +139,6 @@ export function BlogDetail(props: any) {
   }, [id]);
 
   const metaTitle = `${meta_title || title} - Milvus Blog`;
-  const formattedDesc = desc ? desc.replaceAll(/\"/g, '\\"') : '';
-
-  const ldJson = `{"@context": "http://schema.org", "@id": "${shareUrl}", "@type": "Article", "headline": "${title}", "description": "${formattedDesc}", "datePublished": "${new Date(
-    date
-  ).toJSON()}", "name": "${title}", "url": "${shareUrl}"}`;
 
   const hreflangUrls = useMemo(() => {
     const allLangs = Object.values(LanguageEnum);
@@ -161,6 +158,31 @@ export function BlogDetail(props: any) {
 
   const blogLink = locale === 'en' ? '/blog' : `/${locale}/blog`;
   const blogLabel = headerTrans('blog');
+
+  const ldSchemas = useMemo(
+    () => [
+      buildSchema('blogPosting', {
+        absoluteUrl: shareUrl,
+        title,
+        desc,
+        publishTime: date,
+        imageUrl: cover ? `https://${cover}` : undefined,
+        author: author ? { name: author, type: 'Person' } : undefined,
+      }),
+      buildSchema('breadcrumb', [
+        {
+          name: 'Home',
+          url:
+            locale === LanguageEnum.ENGLISH
+              ? ABSOLUTE_BASE_URL
+              : `${ABSOLUTE_BASE_URL}/${locale}`,
+        },
+        { name: blogLabel, url: `${ABSOLUTE_BASE_URL}${blogLink}` },
+        { name: title, url: shareUrl },
+      ]),
+    ],
+    [shareUrl, title, desc, date, cover, author, locale, blogLabel, blogLink]
+  );
 
   return (
     <main>
@@ -189,11 +211,8 @@ export function BlogDetail(props: any) {
               href={entry.url}
             />
           ))}
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: ldJson }}
-          ></script>
         </Head>
+        <JsonLd schema={ldSchemas} />
         <div>
           <div className={clsx(pageClasses.docContainer, styles.upLayout)}>
             <section className={styles.blogHeader}>

--- a/src/components/localization/DocDetail.tsx
+++ b/src/components/localization/DocDetail.tsx
@@ -17,6 +17,9 @@ import { LanguageEnum } from '@/types/localization';
 import { getHomePageLink, getSeoUrl } from '@/components/localization/utils';
 import { useBreadcrumbLabels } from '@/hooks/use-breadcrumb-lables';
 import { useAnchorEventListener } from '@/hooks/use-anchor-event-listener';
+import JsonLd from '@/components/JsonLd';
+import { buildSchema } from '@/schema';
+import { ABSOLUTE_BASE_URL } from '@/consts';
 
 // contains the latest version's detail pages and other versions' home pages
 export function DocDetailPage(props: DocDetailPageProps) {
@@ -47,6 +50,7 @@ export function DocDetailPage(props: DocDetailPageProps) {
 
   const isEN = lang === LanguageEnum.ENGLISH;
   const { t } = useTranslation('docs', { lng: lang });
+  const { t: headerT } = useTranslation('header', { lng: lang });
 
   const seoInfo = useMemo(() => {
     const title = `${frontMatter?.title || headingContent}`;
@@ -81,8 +85,31 @@ export function DocDetailPage(props: DocDetailPageProps) {
     currentId,
     menu: menus,
   });
+
+  // /docs/* is the largest, highest-value corpus → TechArticle + breadcrumb.
+  // Breadcrumb mirrors the visible trail (Home → Docs → page); intermediate
+  // category labels are omitted since they have no standalone URL.
+  const docTitle = `${frontMatter?.title || headingContent}`;
+  const ldSchemas = useMemo(
+    () => [
+      buildSchema('techArticle', {
+        absoluteUrl: seoUrl,
+        title: docTitle,
+        desc: summary || undefined,
+      }),
+      buildSchema('breadcrumb', [
+        { name: 'Home', url: ABSOLUTE_BASE_URL },
+        { name: headerT('docs'), url: `${ABSOLUTE_BASE_URL}${homePageLink}` },
+        { name: docTitle, url: seoUrl },
+      ]),
+    ],
+    [seoUrl, docTitle, summary, homePageLink, headerT]
+  );
+
   return (
-    <DocLayout
+    <>
+      <JsonLd schema={ldSchemas} />
+      <DocLayout
       version={version}
       latestVersion={latestVersion}
       seo={{
@@ -144,6 +171,7 @@ export function DocDetailPage(props: DocDetailPageProps) {
           </div>
         </section>
       }
-    />
+      />
+    </>
   );
 }

--- a/src/pages/ai-quick-reference/[id].tsx
+++ b/src/pages/ai-quick-reference/[id].tsx
@@ -23,6 +23,9 @@ import useUtmTrackPath from '@/hooks/use-utm-track-path';
 import LLMActions, { PageAction, OptionItem } from '@/components/LLMActions';
 import { CopyIcon } from '@/components/icons';
 import { OpenAIIcon, ClaudeAIIcon } from '@/components/icons/AI';
+import JsonLd from '@/components/JsonLd';
+import { buildSchema } from '@/schema';
+import { ABSOLUTE_BASE_URL } from '@/consts';
 
 const FaqDemoCard = dynamic(() => import('@/components/faq/FaqDemoCard'));
 
@@ -78,6 +81,23 @@ export default function FaqDetail(props: {
   const docContainer = useRef<HTMLDivElement>(null);
   const trackPath = useUtmTrackPath();
 
+  // FAQPage is for AI search / machine understanding (no longer a Google rich
+  // result). The page title is the question; the description is its answer.
+  const faqLabel = t('faq:detail.name');
+  const ldSchemas = [
+    description
+      ? buildSchema('faq', {
+          absoluteUrl: canonical_rel,
+          faqItems: [{ question: title, answerPlainText: description }],
+        })
+      : null,
+    buildSchema('breadcrumb', [
+      { name: 'Home', url: ABSOLUTE_BASE_URL },
+      { name: faqLabel, url: `${ABSOLUTE_BASE_URL}/ai-quick-reference` },
+      { name: title, url: canonical_rel },
+    ]),
+  ];
+
   return (
     <Layout>
       <main>
@@ -89,6 +109,7 @@ export default function FaqDetail(props: {
             content={`${title}, zilliz，vector databases，milvus, managed vector databases`}
           />
         </Head>
+        <JsonLd schema={ldSchemas} />
       </main>
       <section className={classes.detailContainer}>
         <div className={clsx(pageClasses.docContainer, styles.upLayout)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,9 @@ import pageClasses from '@/styles/responsive.module.css';
 import { LanguageEnum } from '@/types/localization';
 import { HomeMeta } from '@/parts/home/meta/HomeMeta';
 import { useGlobalLocale } from '@/hooks/use-global-locale';
+import JsonLd from '@/components/JsonLd';
+import { buildSchema } from '@/schema';
+import { CLOUD_SIGNUP_LINK, GITHUB_MILVUS_LINK } from '@/consts';
 
 export default function Homepage(props: {
   headlines: { label: string; link: string; tag: string }[];
@@ -24,6 +27,16 @@ export default function Homepage(props: {
     <Layout headerClassName={pageClasses.homeContainer}>
       <main className={classes.homepageContainer}>
         <HomeMeta locale={locale || LanguageEnum.ENGLISH} />
+        <JsonLd
+          schema={[
+            buildSchema('organization'),
+            buildSchema('website'),
+            buildSchema('softwareApp', {
+              offerUrl: CLOUD_SIGNUP_LINK,
+              codeRepository: GITHUB_MILVUS_LINK,
+            }),
+          ]}
+        />
         <HomePageHeaderSection headlines={headlines} locale={locale} />
         <CodeExampleSection />
         <DeploySection />

--- a/src/pages/learn-ai-and-vectordb/[id].tsx
+++ b/src/pages/learn-ai-and-vectordb/[id].tsx
@@ -19,6 +19,9 @@ import BlogAnchorSection from '@/parts/blogs/blogAnchors';
 import LLMActions, { PageAction, OptionItem } from '@/components/LLMActions';
 import { CopyIcon, checkIconTpl, linkIconTpl } from '@/components/icons';
 import { OpenAIIcon, ClaudeAIIcon } from '@/components/icons/AI';
+import JsonLd from '@/components/JsonLd';
+import { buildSchema } from '@/schema';
+import { ABSOLUTE_BASE_URL } from '@/consts';
 import 'highlight.js/styles/atom-one-dark.css';
 
 const learnAiPageOptions: OptionItem[] = [
@@ -58,9 +61,19 @@ export default function LearnAiDetail(props: {
   const pageHref = useRef('');
 
   const metaTitle = `${title} | Milvus`;
-  const formattedDesc = description ? description.replaceAll(/\"/g, '\\"') : '';
 
-  const ldJson = `{"@context": "http://schema.org", "@id": "${canonical_rel}", "@type": "Article", "headline": "${title}", "description": "${formattedDesc}", "name": "${title}", "url": "${canonical_rel}"}`;
+  const ldSchemas = [
+    buildSchema('techArticle', {
+      absoluteUrl: canonical_rel,
+      title,
+      desc: description,
+    }),
+    buildSchema('breadcrumb', [
+      { name: 'Home', url: ABSOLUTE_BASE_URL },
+      { name: 'Learn AI', url: `${ABSOLUTE_BASE_URL}/learn-ai-and-vectordb` },
+      { name: title, url: canonical_rel },
+    ]),
+  ];
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -100,11 +113,8 @@ export default function LearnAiDetail(props: {
           <meta name="description" content={description} />
           <meta name="keywords" content={meta_keywords} />
           <link rel="canonical" href={canonical_rel} />
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: ldJson }}
-          ></script>
         </Head>
+        <JsonLd schema={ldSchemas} />
       </main>
       <section className={classes.detailContainer}>
         <div className={clsx(pageClasses.docContainer, styles.upLayout)}>

--- a/src/schema/buildSchema.ts
+++ b/src/schema/buildSchema.ts
@@ -1,0 +1,70 @@
+import {
+  articleSchema,
+  organizationSchema,
+  websiteSchema,
+  breadcrumbSchema,
+  faqSchema,
+  videoSchema,
+  softwareAppSchema,
+  definedTermSchema,
+  eventSchema,
+  jobPostingSchema,
+  type SchemaObject,
+} from './generators';
+
+export type SchemaPageType =
+  | 'article'
+  | 'techArticle'
+  | 'blogPosting'
+  | 'newsArticle'
+  | 'organization'
+  | 'website'
+  | 'event'
+  | 'video'
+  | 'faq'
+  | 'breadcrumb'
+  | 'softwareApp'
+  | 'definedTerm'
+  | 'jobPosting';
+
+/**
+ * Single entry point for producing a JSON-LD object. Every route should call
+ * this rather than hand-assembling schema, so the conventions (https context,
+ * @id fragments, publisher → homepage Organization) stay consistent and new
+ * page types only cost one extra generator + one call site.
+ */
+export function buildSchema(
+  pageType: SchemaPageType,
+  data?: any
+): SchemaObject {
+  switch (pageType) {
+    case 'article':
+      return articleSchema(data);
+    case 'techArticle':
+      return articleSchema({ ...data, type: 'TechArticle' });
+    case 'blogPosting':
+      return articleSchema({ ...data, type: 'BlogPosting' });
+    case 'newsArticle':
+      return articleSchema({ ...data, type: 'NewsArticle' });
+    case 'organization':
+      return organizationSchema();
+    case 'website':
+      return websiteSchema();
+    case 'event':
+      return eventSchema(data);
+    case 'video':
+      return videoSchema(data);
+    case 'faq':
+      return faqSchema(data);
+    case 'breadcrumb':
+      return breadcrumbSchema(data);
+    case 'softwareApp':
+      return softwareAppSchema(data);
+    case 'definedTerm':
+      return definedTermSchema(data);
+    case 'jobPosting':
+      return jobPostingSchema(data);
+    default:
+      throw new Error(`Unknown pageType: ${pageType}`);
+  }
+}

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -1,0 +1,35 @@
+import {
+  ABSOLUTE_BASE_URL,
+  GITHUB_MILVUS_LINK,
+  MILVUS_TWITTER_LINK,
+  MILVUS_LINKEDIN_URL,
+  MILVUS_YOUTUBE_CHANNEL_LINK,
+} from '@/consts';
+
+/**
+ * Single source of truth for site-level identity used by every JSON-LD
+ * generator. Keeping domain / brand / logo / social links here means each
+ * generator just references SITE instead of re-declaring them.
+ */
+export const SITE = {
+  name: 'Milvus',
+  url: ABSOLUTE_BASE_URL,
+  /** Stable @id for the Organization node, referenced by publisher/author/etc. */
+  orgId: `${ABSOLUTE_BASE_URL}/#organization`,
+  /** Stable @id for the WebSite node. */
+  websiteId: `${ABSOLUTE_BASE_URL}/#website`,
+  /**
+   * Organization logo. Google requires a raster format (PNG/JPG) for the
+   * logo property — SVG is NOT accepted — so this points at the PNG lockup,
+   * not the SVG used elsewhere in the UI.
+   */
+  logo: `${ABSOLUTE_BASE_URL}/images/milvus-logo-group.png`,
+  description:
+    'Milvus is an open-source vector database built for GenAI applications, enabling fast and scalable similarity search over billions of vectors.',
+  sameAs: [
+    GITHUB_MILVUS_LINK,
+    MILVUS_TWITTER_LINK,
+    MILVUS_LINKEDIN_URL,
+    MILVUS_YOUTUBE_CHANNEL_LINK,
+  ],
+} as const;

--- a/src/schema/generators.ts
+++ b/src/schema/generators.ts
@@ -1,0 +1,318 @@
+import { SITE } from './constants';
+
+const SCHEMA_CONTEXT = 'https://schema.org';
+
+/** A plain JSON-LD object. Generators return objects; the `<JsonLd>` component
+ *  serializes them with JSON.stringify so quotes/newlines can never produce
+ *  invalid JSON (the bug that hand-built template strings used to have). */
+export type SchemaObject = Record<string, any>;
+
+type DateInput = string | number | Date | null | undefined;
+
+/** Normalize any date-ish value to an ISO 8601 string, or undefined. */
+const toISO = (date: DateInput): string | undefined => {
+  if (!date) return undefined;
+  const d = new Date(date);
+  return Number.isNaN(d.getTime()) ? undefined : d.toJSON();
+};
+
+export type ArticleType =
+  | 'Article'
+  | 'BlogPosting'
+  | 'TechArticle'
+  | 'NewsArticle';
+
+export interface ArticleInput {
+  type?: ArticleType;
+  absoluteUrl: string;
+  title: string;
+  desc?: string;
+  publishTime?: DateInput;
+  modifiedTime?: DateInput;
+  imageUrl?: string;
+  /** Named human author; falls back to the Organization when absent. */
+  author?: { name?: string; type?: 'Person' | 'Organization' };
+}
+
+/** Article / BlogPosting / TechArticle / NewsArticle — the generic content page. */
+export function articleSchema({
+  type = 'Article',
+  absoluteUrl,
+  title,
+  desc,
+  publishTime,
+  modifiedTime,
+  imageUrl,
+  author,
+}: ArticleInput): SchemaObject {
+  const datePublished = toISO(publishTime);
+  const dateModified = toISO(modifiedTime) || datePublished;
+
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': type,
+    '@id': `${absoluteUrl}#article`,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': absoluteUrl },
+    url: absoluteUrl,
+    headline: title.slice(0, 110), // Google recommends ≤110 chars
+    description: desc || undefined,
+    image: imageUrl ? [imageUrl] : undefined,
+    datePublished,
+    dateModified,
+    author:
+      author?.name && author.type === 'Person'
+        ? { '@type': 'Person', name: author.name }
+        : { '@type': 'Organization', name: SITE.name, url: SITE.url },
+    publisher: { '@id': SITE.orgId }, // points at the homepage Organization
+  };
+}
+
+/** Organization node — defined once on the homepage, referenced everywhere via @id. */
+export function organizationSchema(): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'Organization',
+    '@id': SITE.orgId,
+    name: SITE.name,
+    url: SITE.url,
+    logo: SITE.logo,
+    description: SITE.description,
+    sameAs: SITE.sameAs,
+  };
+}
+
+/** WebSite node — homepage only. */
+export function websiteSchema(): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'WebSite',
+    '@id': SITE.websiteId,
+    url: SITE.url,
+    name: SITE.name,
+    publisher: { '@id': SITE.orgId },
+  };
+}
+
+export interface BreadcrumbItem {
+  name: string;
+  url?: string;
+}
+
+/** BreadcrumbList from a Home→…→current trail. The last item may omit its url. */
+export function breadcrumbSchema(items: BreadcrumbItem[]): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      ...(item.url ? { item: item.url } : {}),
+    })),
+  };
+}
+
+export interface FaqInput {
+  absoluteUrl: string;
+  faqItems: { question: string; answerPlainText: string }[];
+}
+
+/** FAQPage — for AI search / machine understanding (no longer a Google rich
+ *  result since 2026-05). faqItems must be real, page-visible Q&A. */
+export function faqSchema({ absoluteUrl, faqItems }: FaqInput): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'FAQPage',
+    '@id': `${absoluteUrl}#faq`,
+    mainEntity: faqItems.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answerPlainText },
+    })),
+  };
+}
+
+export interface VideoInput {
+  name: string;
+  desc?: string;
+  thumbnailUrl: string;
+  uploadDate: DateInput;
+  contentUrl?: string;
+  embedUrl?: string;
+  /** ISO 8601 duration, e.g. "PT1H02M". */
+  duration?: string;
+}
+
+/** VideoObject — webinar replays / embedded YouTube. */
+export function videoSchema({
+  name,
+  desc,
+  thumbnailUrl,
+  uploadDate,
+  contentUrl,
+  embedUrl,
+  duration,
+}: VideoInput): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'VideoObject',
+    name,
+    description: desc || undefined,
+    thumbnailUrl: [thumbnailUrl],
+    uploadDate: toISO(uploadDate),
+    contentUrl,
+    embedUrl,
+    duration,
+    publisher: { '@id': SITE.orgId },
+  };
+}
+
+export interface SoftwareAppInput {
+  name?: string;
+  desc?: string;
+  url?: string;
+  offerUrl?: string;
+  /** Open-source repository — adds codeRepository semantics. */
+  codeRepository?: string;
+}
+
+/** SoftwareApplication — product pages. Never add aggregateRating/review
+ *  (self-rating violates Google policy). */
+export function softwareAppSchema({
+  name = SITE.name,
+  desc = SITE.description,
+  url = SITE.url,
+  offerUrl,
+  codeRepository,
+}: SoftwareAppInput = {}): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'SoftwareApplication',
+    name,
+    description: desc,
+    url,
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Cloud / Linux / macOS / Windows',
+    publisher: { '@id': SITE.orgId },
+    ...(codeRepository ? { codeRepository } : {}),
+    offers: offerUrl
+      ? {
+          '@type': 'Offer',
+          url: offerUrl,
+          price: '0',
+          priceCurrency: 'USD',
+        }
+      : undefined,
+  };
+}
+
+export interface DefinedTermInput {
+  term: string;
+  definition: string;
+  url: string;
+  /** The DefinedTermSet this term belongs to (e.g. a glossary index URL). */
+  termSetUrl?: string;
+}
+
+/** DefinedTerm — glossary entries. */
+export function definedTermSchema({
+  term,
+  definition,
+  url,
+  termSetUrl,
+}: DefinedTermInput): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'DefinedTerm',
+    name: term,
+    description: definition,
+    url,
+    ...(termSetUrl ? { inDefinedTermSet: termSetUrl } : {}),
+  };
+}
+
+export interface EventInput {
+  name: string;
+  desc?: string;
+  startDate: DateInput;
+  endDate?: DateInput;
+  url: string;
+  locationName?: string;
+  address?: string;
+  isOnline?: boolean;
+  imageUrl?: string;
+}
+
+/** Event — still a Google rich result. Required: name, startDate, location. */
+export function eventSchema({
+  name,
+  desc,
+  startDate,
+  endDate,
+  url,
+  locationName,
+  address,
+  isOnline,
+  imageUrl,
+}: EventInput): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'Event',
+    name,
+    description: desc || undefined,
+    startDate: toISO(startDate),
+    endDate: toISO(endDate),
+    eventAttendanceMode: isOnline
+      ? 'https://schema.org/OnlineEventAttendanceMode'
+      : 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: isOnline
+      ? { '@type': 'VirtualLocation', url }
+      : { '@type': 'Place', name: locationName, address },
+    image: imageUrl ? [imageUrl] : undefined,
+    organizer: { '@id': SITE.orgId },
+    offers: {
+      '@type': 'Offer',
+      url,
+      price: '0',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+    },
+  };
+}
+
+export interface JobPostingInput {
+  title: string;
+  desc: string;
+  datePosted: DateInput;
+  validThrough?: DateInput;
+  employmentType?: string;
+  locationAddress?: string;
+  remote?: boolean;
+}
+
+/** JobPosting — careers pages with a real listing. */
+export function jobPostingSchema({
+  title,
+  desc,
+  datePosted,
+  validThrough,
+  employmentType,
+  locationAddress,
+  remote,
+}: JobPostingInput): SchemaObject {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'JobPosting',
+    title,
+    description: desc,
+    datePosted: toISO(datePosted),
+    validThrough: toISO(validThrough),
+    employmentType,
+    hiringOrganization: { '@id': SITE.orgId },
+    jobLocationType: remote ? 'TELECOMMUTE' : undefined,
+    jobLocation: remote
+      ? undefined
+      : { '@type': 'Place', address: locationAddress },
+  };
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,3 @@
+export { SITE } from './constants';
+export { buildSchema, type SchemaPageType } from './buildSchema';
+export * from './generators';


### PR DESCRIPTION
## 背景

需求文档：[Zilliz / Milvus 结构化数据 (Schema.org) 实施规范](https://zilliverse.feishu.cn/docx/Xibkdvq5ToxLb8xFM1pcVtnKnZd)

现状两个问题（文档背景与现状）：
- 现有 Article JSON-LD（blog 详情、learn-ai 详情）是**手工字符串拼接** + `@context: "http://schema.org"`，标题/描述里的引号、换行会生成**非法 JSON**。
- 大量高价值页面（首页、docs、ai-quick-reference）**完全没有** structured data。

本 PR 覆盖文档中 **milvus.io 适用的 Phase 0–3**（Event/JobPosting/glossary/customers/pricing 等是 zilliz.com 专属路由，milvus.io 没有，故跳过）。

## 改动

**集中式 Schema 工厂**（文档第 2 节架构）— 新增 `src/schema/`：
- `constants.ts` — `SITE` 单一事实源（域名/品牌/logo/sameAs）
- `generators.ts` — 全部生成器（article/blogPosting/techArticle/newsArticle/organization/website/breadcrumb/faq/video/softwareApp/definedTerm/event/jobPosting）
- `buildSchema.ts` — `switch` 分发器
- `src/components/JsonLd/index.tsx` — 统一注入组件（多对象、唯一 key、`JSON.stringify`）

**统一约定**：一律 `https://schema.org`、一律 `JSON.stringify`、`@id` 用 `#fragment`、`publisher/author/organizer` 的 `@id` 指向首页 Organization（形成实体图）。

**逐页接入**：

| 页面 | Schema |
|---|---|
| 首页 | Organization + WebSite + SoftwareApplication（开源，**无自评 rating**，含 codeRepository + 免费 Offer） |
| `/blog/[id]` | BlogPosting + BreadcrumbList（原 http Article） |
| `/learn-ai-and-vectordb/[id]` | TechArticle + BreadcrumbList（原 http Article） |
| `/ai-quick-reference/[id]` | FAQPage（为 AI 搜索）+ BreadcrumbList |
| `/docs/*`（全语言全版本，量最大价值最高） | TechArticle + BreadcrumbList |
| `/learn-milvus/*` | breadcrumb/faq 迁移到工厂 |

## 决策点

- **Logo 用 PNG**：Google 的 Organization logo 不接受 SVG，仓库 layout 下只有 SVG，故改用 `public/images/milvus-logo-group.png`（878×260，公开可访问）。
- **跳过的类型**：Event / JobPosting / DefinedTerm / Video 生成器已在工厂里备好但无调用点（对应路由是 zilliz 专属或 milvus.io 暂无）。后续新增页面只需加一次调用，边际成本极低。
- **SoftwareApplication 放首页**（文档 Phase 3 "milvus /intro" 对应 milvus.io 首页）。
- **FAQPage 答案**取页面 `description`，标题作为问题。

## 验证

- `tsc --noEmit`：本次改/加的文件零错误（仅剩一个 `markdown-it` 预存错误，base 上本就有，与本 PR 无关）。
- 单独编译 `schema` + `consts` 跑运行时测试：所有生成器输出**合法 JSON**，含特殊字符（引号/换行/`&`/`<`）的标题描述正确转义，headline 截断到 110 字符。

## 上线后建议（文档验收清单）

- Schema.org Validator + Google Rich Results Test 跑一遍 Article / Breadcrumb / FAQ。
- 上线后看 GSC 富结果报告，跟踪 Article / Breadcrumb 有效项与错误项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)