### PR TITLE
fix(seo): re-admit zh/ko/zh-hant/ja to sitemap with Plan B canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ marketing-automation-plan.md
 
 openspec/
 .claude/
+tsconfig.tsbuildinfo

--- a/sitemap.config.js
+++ b/sitemap.config.js
@@ -68,17 +68,18 @@ const generateFaqPaths = () => {
   });
 };
 
-// Keep the sitemap focused on high-value canonical URLs: English blog and the
-// English latest-version docs. We stop advertising the localized and
-// old-version long tail — Google discovers those from the sitemap but defers
-// crawling/indexing them ("Discovered/Crawled - currently not indexed"), which
-// just dilutes crawl budget. api-reference, ai-quick-reference and landing
+// Keep the sitemap focused on high-value canonical URLs: English plus the
+// non-English languages that carry real GSC traffic (zh/ko/zh-hant/ja), at
+// their latest doc version only. We stop advertising the rest of the localized
+// and old-version long tail — Google discovers those from the sitemap but
+// defers crawling/indexing them ("Discovered/Crawled - currently not indexed"),
+// which just dilutes crawl budget. api-reference, ai-quick-reference and landing
 // pages (incl. localized landing pages) are intentionally left untouched.
-const NON_EN_LANGS = [
-  'zh-hant',
-  'zh',
-  'ja',
-  'ko',
+//
+// INDEXABLE_NON_EN_LANGS must stay in sync with INDEXABLE_LANGUAGES in
+// src/types/localization.ts (this file is CommonJS and cannot import it).
+const INDEXABLE_NON_EN_LANGS = ['zh-hant', 'zh', 'ja', 'ko'];
+const CUT_LANGS = [
   'fr',
   'de',
   'es',
@@ -89,9 +90,15 @@ const NON_EN_LANGS = [
   'ar',
   'cn',
 ];
-const LOCALIZED_BLOG_RE = new RegExp(`^/(${NON_EN_LANGS.join('|')})/blog(/|$)`);
-const LOCALIZED_DOCS_RE = new RegExp(`^/docs/(${NON_EN_LANGS.join('|')})(/|$)`);
-const VERSIONED_DOCS_RE = /^\/docs\/v\d+\.\d+\.x(\/|$)/;
+// Non-indexable languages: their blog and docs URLs never enter the sitemap.
+const LOCALIZED_BLOG_RE = new RegExp(`^/(${CUT_LANGS.join('|')})/blog(/|$)`);
+const LOCALIZED_DOCS_RE = new RegExp(`^/docs/(${CUT_LANGS.join('|')})(/|$)`);
+// Old (non-latest) doc versions are excluded for every kept language, English
+// (/docs/v2.6.x/...) and indexable non-English (/docs/zh/v2.6.x/...) alike.
+// Only the latest version, which uses an unversioned URL, stays in the sitemap.
+const VERSIONED_DOCS_RE = new RegExp(
+  `^/docs/(?:(?:${INDEXABLE_NON_EN_LANGS.join('|')})/)?v\\d+\\.\\d+\\.x(/|$)`
+);
 
 const toPathname = loc => {
   try {

--- a/src/components/layout/commonLayout/index.tsx
+++ b/src/components/layout/commonLayout/index.tsx
@@ -3,6 +3,7 @@ import Header from '../../header';
 import Footer from '../../footer';
 import { ABSOLUTE_BASE_URL } from '@/consts';
 import { useGlobalLocale } from '@/hooks/use-global-locale';
+import { isIndexableLanguage } from '@/types/localization';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 
@@ -19,6 +20,10 @@ const Layout: React.FC<{
   // two conflicting tags make Google drop both ("Duplicate without
   // user-selected canonical"). Defaults to self for all other pages.
   canonicalUrl?: string;
+  // Suppress the default self-referential hreflang. Pages that emit their own
+  // complete hreflang cluster (e.g. blog detail) set this so the cluster isn't
+  // duplicated or polluted with a non-indexable self-reference.
+  disableSelfHreflang?: boolean;
 }> = ({
   darkMode,
   children,
@@ -26,6 +31,7 @@ const Layout: React.FC<{
   headerClassName,
   disableLangSelector = false,
   canonicalUrl,
+  disableSelfHreflang = false,
 }) => {
   const { locale } = useGlobalLocale();
   const { asPath } = useRouter();
@@ -37,9 +43,12 @@ const Layout: React.FC<{
     <>
       <Head>
         <link rel="canonical" href={canonicalUrl ?? selfUrl} />
-        {/* hreflang stays self-referential: it declares this page as the
-            alternate for its own language, regardless of canonical target. */}
-        <link rel="alternate" hrefLang={locale} href={selfUrl} />
+        {/* Self-referential hreflang, only for indexable languages so we don't
+            advertise pages that are consolidated to English. Pages owning their
+            full cluster opt out via disableSelfHreflang. */}
+        {!disableSelfHreflang && isIndexableLanguage(locale) && (
+          <link rel="alternate" hrefLang={locale} href={selfUrl} />
+        )}
       </Head>
       <Header
         darkMode={darkMode}

--- a/src/components/localization/BlogDetail.tsx
+++ b/src/components/localization/BlogDetail.tsx
@@ -65,6 +65,7 @@ export function BlogDetail(props: any) {
     meta_title,
     meta_keywords = 'vector databases, milvus, open-source vector database, vector search',
     canonicalUrl,
+    availableLanguages = [],
   } = props;
   const router = useRouter();
   const docContainer = useRef(null);
@@ -140,9 +141,14 @@ export function BlogDetail(props: any) {
 
   const metaTitle = `${meta_title || title} - Milvus Blog`;
 
+  // hreflang cluster only lists indexable languages that actually have a
+  // translation of this post (availableLanguages is already filtered to the
+  // indexable set in CreateBlogDetailProps), so every entry is a reciprocal,
+  // self-canonical 200 page. x-default points to the English version.
   const hreflangUrls = useMemo(() => {
-    const allLangs = Object.values(LanguageEnum);
-    const entries: { lang: string; url: string; }[] = allLangs.map(lang => {
+    const entries: { lang: string; url: string }[] = (
+      availableLanguages as LanguageEnum[]
+    ).map(lang => {
       const prefix = lang === LanguageEnum.ENGLISH ? '' : `/${lang}`;
       return {
         lang,
@@ -154,7 +160,7 @@ export function BlogDetail(props: any) {
       entries.push({ lang: 'x-default', url: enEntry.url });
     }
     return entries;
-  }, [id]);
+  }, [id, availableLanguages]);
 
   const blogLink = locale === 'en' ? '/blog' : `/${locale}/blog`;
   const blogLabel = headerTrans('blog');
@@ -189,6 +195,7 @@ export function BlogDetail(props: any) {
       <Layout
         headerClassName={pageClasses.blogContainer}
         canonicalUrl={canonicalUrl || shareUrl}
+        disableSelfHreflang
       >
         <Head>
           <title>{metaTitle}</title>

--- a/src/components/localization/CreateBlogDetailProps.ts
+++ b/src/components/localization/CreateBlogDetailProps.ts
@@ -1,5 +1,5 @@
 import blogUtils from '@/utils/blog.utils';
-import { LanguageEnum } from '@/types/localization';
+import { isIndexableLanguage, LanguageEnum } from '@/types/localization';
 import { markdownToHtml } from '@/utils/markdown';
 import { ABSOLUTE_BASE_URL } from '@/consts';
 
@@ -48,14 +48,29 @@ export const createBlogDetailProps = (lang: LanguageEnum) => {
       .filter(v => v.tags.some(tag => tags.includes(tag) && v.id !== id))
       .slice(0, 4);
 
-    // For non-English locales, derive canonical from the English blog:
-    // - If English blog has canonicalUrl (e.g., zilliz.com cross-post), use it
-    // - Otherwise, point to the English milvus.io blog URL
-    let canonicalUrl = (rest as Record<string, any>).canonicalUrl ?? null;
+    // Canonical strategy by language:
+    // - A cross-post (English blog has an external canonicalUrl, e.g. a
+    //   zilliz.com original) always wins for every language — none of these
+    //   should be indexed on milvus.io.
+    // - Indexable languages (en/zh/ko/zh-hant/ja) self-reference so each gets
+    //   indexed, paired with the hreflang cluster emitted in BlogDetail.
+    // - Every other language points to the English milvus.io blog URL to
+    //   consolidate it to English instead of competing for the index.
+    const enBlog = enData.find(v => v.id === id) as
+      | Record<string, any>
+      | undefined;
+    const enCanonicalUrl = enBlog?.canonicalUrl as string | undefined;
+    let canonicalUrl: string | null =
+      (rest as Record<string, any>).canonicalUrl ?? null;
     if (lang !== LanguageEnum.ENGLISH) {
-      const enBlog = enData.find(v => v.id === id) as Record<string, any> | undefined;
-      canonicalUrl = enBlog?.canonicalUrl || `${ABSOLUTE_BASE_URL}/blog/${id}`;
+      canonicalUrl =
+        enCanonicalUrl ||
+        (isIndexableLanguage(lang)
+          ? `${ABSOLUTE_BASE_URL}/${lang}/blog/${id}`
+          : `${ABSOLUTE_BASE_URL}/blog/${id}`);
     }
+
+    const availableLanguages = blogUtils.getAvailableLanguages(id);
 
     return {
       props: {
@@ -71,6 +86,7 @@ export const createBlogDetailProps = (lang: LanguageEnum) => {
         tags,
         ...rest,
         canonicalUrl,
+        availableLanguages,
       },
     };
   };

--- a/src/components/localization/utils.ts
+++ b/src/components/localization/utils.ts
@@ -1,4 +1,4 @@
-import { LanguageEnum } from '@/types/localization';
+import { isIndexableLanguage, LanguageEnum } from '@/types/localization';
 import { ABSOLUTE_BASE_URL } from '@/consts';
 
 interface HreflangEntry {
@@ -6,8 +6,11 @@ interface HreflangEntry {
   url: string;
 }
 
-// Generate hreflang entries for all available languages of a doc within the same version.
-// x-default points to English version.
+// Generate hreflang entries for a doc within the same version. The cluster only
+// contains indexable languages (en/zh/ko/zh-hant/ja) that actually have this
+// doc at this version, so every entry is a self-canonical, reciprocal 200 page.
+// hreflang clusters per-version: it never links across versions. x-default
+// points to the English version.
 export const getDocHreflangUrls = (params: {
   version: string;
   latestVersion: string;
@@ -18,13 +21,15 @@ export const getDocHreflangUrls = (params: {
   const versionSuffix = version === latestVersion ? '' : `/${version}`;
   const docIdSuffix = docId ? `/${docId}` : '';
 
-  const entries: HreflangEntry[] = availableLanguages.map(lang => {
-    const langSuffix = lang === LanguageEnum.ENGLISH ? '' : `/${lang}`;
-    return {
-      lang,
-      url: `${ABSOLUTE_BASE_URL}/docs${langSuffix}${versionSuffix}${docIdSuffix}`,
-    };
-  });
+  const entries: HreflangEntry[] = availableLanguages
+    .filter(isIndexableLanguage)
+    .map(lang => {
+      const langSuffix = lang === LanguageEnum.ENGLISH ? '' : `/${lang}`;
+      return {
+        lang,
+        url: `${ABSOLUTE_BASE_URL}/docs${langSuffix}${versionSuffix}${docIdSuffix}`,
+      };
+    });
 
   // x-default points to the English version
   const enEntry = entries.find(e => e.lang === LanguageEnum.ENGLISH);
@@ -96,10 +101,16 @@ export const getApiCanonicalUrl = (params: {
   return `${ABSOLUTE_BASE_URL}/api-reference/${languageCategory}${targetRelativePath}`;
 };
 
-// Canonical URL should represent the current docs version. The latest
-// version uses the unversioned docs URL, while archived versions keep their
-// version segment (for example, /docs/v2.6.x) so search engines don't treat
-// them as duplicates of the latest docs.
+// Canonical URL for a doc page, handling both the version and language axes:
+// - Version: always self-references the current version. Archived versions keep
+//   their version segment (for example, /docs/v2.6.x) because old versions are
+//   distinct content, not duplicates of the latest docs — we never collapse a
+//   version onto another (which could point at a non-equivalent or missing page).
+// - Language: indexable languages (en/zh/ko/zh-hant/ja) self-reference so each
+//   gets indexed; every other language drops its language segment and points to
+//   the English page of the SAME version, consolidating it to English instead of
+//   competing for the index. The English source always has the same docId, so
+//   this target is guaranteed to exist.
 export const getDocCanonicalUrl = (params: {
   lang: LanguageEnum;
   version: string;
@@ -107,7 +118,8 @@ export const getDocCanonicalUrl = (params: {
   docId?: string;
 }): string => {
   const { lang, version, latestVersion, docId } = params;
-  const langSuffix = lang === LanguageEnum.ENGLISH ? '' : `/${lang}`;
+  const langSuffix =
+    isIndexableLanguage(lang) && lang !== LanguageEnum.ENGLISH ? `/${lang}` : '';
   const versionSuffix = version === latestVersion ? '' : `/${version}`;
   const docIdSuffix = docId ? `/${docId}` : '';
 

--- a/src/types/localization.ts
+++ b/src/types/localization.ts
@@ -13,3 +13,22 @@ export enum LanguageEnum {
   INDONESIAN = 'id',
   ARABIC = 'ar',
 }
+
+// Languages we want search engines to index. These are advertised in the
+// sitemap and form the hreflang cluster; every other language self-references
+// the user-facing page but canonicalizes to English so it is consolidated
+// instead of competing for the index. Driven by GSC click data — only English
+// plus zh/ko/zh-hant/ja carry meaningful non-English traffic.
+//
+// NOTE: sitemap.config.js (CommonJS) keeps its own copy of this list and must
+// be kept in sync with this constant.
+export const INDEXABLE_LANGUAGES: LanguageEnum[] = [
+  LanguageEnum.ENGLISH,
+  LanguageEnum.CHINESE,
+  LanguageEnum.KOREAN,
+  LanguageEnum.CHINESE_TW,
+  LanguageEnum.JAPANESE,
+];
+
+export const isIndexableLanguage = (lang: LanguageEnum | string): boolean =>
+  INDEXABLE_LANGUAGES.includes(lang as LanguageEnum);

--- a/src/utils/blog.utils.ts
+++ b/src/utils/blog.utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import matter from 'gray-matter';
-import { LanguageEnum } from '@/types/localization';
+import { INDEXABLE_LANGUAGES, LanguageEnum } from '@/types/localization';
 
 const generateBlogCover = (cover: string, date: Date) => {
   if (cover) {
@@ -122,11 +122,19 @@ const generateBlogRouter = (locale: LanguageEnum) => {
   return router;
 };
 
+// Indexable languages that actually provide a translation of this blog post,
+// used to build a reciprocal hreflang cluster that never points at a 404.
+const getAvailableLanguagesForBlog = (id: string) =>
+  INDEXABLE_LANGUAGES.filter(locale =>
+    fs.existsSync(join(getBlogDir(locale), id))
+  );
+
 const blogUtils = {
   getAllData: generateBlogData,
   getListData: generateBlogListData,
   getRouter: generateBlogRouter,
   getSimpleList: generateSimpleBlogList,
+  getAvailableLanguages: getAvailableLanguagesForBlog,
 };
 
 export default blogUtils;


### PR DESCRIPTION
## 背景

按反馈文档 Milvus 反馈 3）小节调整 SEO。上一轮把**所有非英文**页面移出了 sitemap；GSC 点击数据显示英文 + zh/ko/zh-hant/ja 有真实流量（zh ~8 万、ko ~4 万），需要把这 4 个语言加回来并走 Plan B（自指 canonical + hreflang），其余语言（含 ru）继续砍掉。

## 可索引语言集

新增 `INDEXABLE_LANGUAGES = [en, zh, ko, zh-hant, ja]` 作为单一来源，在 sitemap / canonical / hreflang 三处一致落地。

- **进 sitemap**：英文全量（最新版）+ zh/ko/zh-hant/ja 最新版 docs；英文 + 这 4 语言的 blog。
- **排除**：所有旧版本 docs（含保留语言）、`fr/de/es/it/pt/ru/id/ar/cn` 的全部 docs+blog。

## canonical / hreflang 策略（符合标准）

docs 有"语言 × 版本"两个维度：

- **版本维度**：永远自指当前版本，绝不跨版本合并（旧版本是不同内容，避免 canonical 指向不等价/不存在页）。
- **语言维度**：可索引语言自指；其余语言去掉语言段→指**英文同版本**（源页必然存在，不会 404）。
- **hreflang**：仅按"同版本 + 可索引 + 确有译文"聚类，每条都是对称、自指的 200 页，与 canonical 不冲突。
- **blog**：可索引语言自指、其余指英文、跨站转载优先；hreflang 保留存在性校验（existsSync），不再指向 404。

## 改动文件

- `src/types/localization.ts` — 新增 `INDEXABLE_LANGUAGES` + `isIndexableLanguage()`
- `sitemap.config.js` — `CUT_LANGS` 排除 + `VERSIONED_DOCS_RE` 扩展（排除保留语言旧版本）
- `src/components/localization/utils.ts` — docs canonical / hreflang
- `src/components/localization/CreateBlogDetailProps.ts` — blog canonical + 传 `availableLanguages`
- `src/components/localization/BlogDetail.tsx` — blog hreflang 用 `availableLanguages`
- `src/utils/blog.utils.ts` — 新增 `getAvailableLanguages(id)`

## 验证

- `tsc --noEmit` 改动文件无新增报错。
- sitemap 排除正则用 18 个代表性 URL 全部通过（保留语言最新版入站、旧版本/砍掉语言不入站、api-reference/landing 不受影响）。
- ⚠️ 尚未跑完整 `pnpm build` 验证 sitemap 产物，建议合并前抽查 `public/sitemap*.xml`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)