### PR TITLE
fix(seo): fix empty BreadcrumbList name from title-less blog stubs

### DIFF
--- a/src/schema/generators.ts
+++ b/src/schema/generators.ts
@@ -98,12 +98,18 @@ export interface BreadcrumbItem {
   url?: string;
 }
 
-/** BreadcrumbList from a Home→…→current trail. The last item may omit its url. */
+/** BreadcrumbList from a Home→…→current trail. The last item may omit its url.
+ *  Items whose name is empty/blank are dropped and positions are renumbered so
+ *  every ListItem always carries a non-empty `name` — otherwise Google reports
+ *  "Either 'name' or 'item.name' should be specified (in 'itemListElement')". */
 export function breadcrumbSchema(items: BreadcrumbItem[]): SchemaObject {
+  const named = (items ?? [])
+    .map(item => ({ ...item, name: item.name?.trim() }))
+    .filter((item): item is BreadcrumbItem & { name: string } => !!item.name);
   return {
     '@context': SCHEMA_CONTEXT,
     '@type': 'BreadcrumbList',
-    itemListElement: items.map((item, index) => ({
+    itemListElement: named.map((item, index) => ({
       '@type': 'ListItem',
       position: index + 1,
       name: item.name,

--- a/src/utils/blog.utils.ts
+++ b/src/utils/blog.utils.ts
@@ -21,8 +21,22 @@ const getBlogDir = (locale: LanguageEnum = LanguageEnum.ENGLISH) =>
     ? join(process.cwd(), 'src/blogs/blog/en')
     : join(process.cwd(), `src/blogs/localization/blog/${locale}`);
 
+/** A blog markdown file is routable only if its frontmatter carries a
+ *  non-empty `title`. Empty/placeholder stubs — e.g. the 1-byte untranslated
+ *  files under localization/blog/<locale> — otherwise generate blank-title
+ *  routes that also emit an empty BreadcrumbList `name`, which Google Search
+ *  Console flags as invalid structured data. Skipping them here keeps them out
+ *  of every consumer at once: routes, list, sitemap, hreflang. */
+const hasBlogTitle = (blogDir: string, fileName: string) => {
+  const { data } = matter(fs.readFileSync(`${blogDir}/${fileName}`));
+  return typeof data.title === 'string' && data.title.trim().length > 0;
+};
+
 const getBlogFileNames = (blogDir: string) =>
-  fs.readdirSync(blogDir).filter(fileName => fileName.endsWith('.md'));
+  fs
+    .readdirSync(blogDir)
+    .filter(fileName => fileName.endsWith('.md'))
+    .filter(fileName => hasBlogTitle(blogDir, fileName));
 
 const sortBlogsByDateDesc = <T extends { date: string }>(blogsData: T[]) => {
   blogsData.sort(
@@ -125,9 +139,10 @@ const generateBlogRouter = (locale: LanguageEnum) => {
 // Indexable languages that actually provide a translation of this blog post,
 // used to build a reciprocal hreflang cluster that never points at a 404.
 const getAvailableLanguagesForBlog = (id: string) =>
-  INDEXABLE_LANGUAGES.filter(locale =>
-    fs.existsSync(join(getBlogDir(locale), id))
-  );
+  INDEXABLE_LANGUAGES.filter(locale => {
+    const dir = getBlogDir(locale);
+    return fs.existsSync(join(dir, id)) && hasBlogTitle(dir, id);
+  });
 
 const blogUtils = {
   getAllData: generateBlogData,


### PR DESCRIPTION
## Problem

Google Search Console reported a **critical** Breadcrumbs structured-data issue for milvus.io:

> Either "name" or "item.name" should be specified (in "itemListElement")

## Root cause

The affected URL GSC surfaced was `https://milvus.io/id/blog/2021-05-13-building-a-search-by-image-shopping-experience-with-vova-and-milvus.md`.

That post exists as **1-byte empty stub files across all 13 locales** (EN original + 12 localizations) in the `src/blogs` submodule (`milvus-io/community`). `getBlogFileNames()` admitted any `*.md`, so each stub generated a real static route. With no frontmatter, `const { title = '' } = data` yields `title = ''`, so the `BlogPosting` breadcrumb emits a `ListItem` whose `name` is empty — `JSON.stringify` drops the empty `name` key and `item` is only a URL string (no `item.name`), which is exactly the GSC error. Every locale variant (`/blog/...md`, `/<lang>/blog/...md`) was affected.

## Fix (two layers)

**1. Stop title-less blogs from routing** (`src/utils/blog.utils.ts`) — the real fix. `getBlogFileNames` now requires a non-empty frontmatter `title` (new `hasBlogTitle`). The empty stubs disappear from every consumer at once: routes, blog list, sitemap, and the hreflang cluster (`getAvailableLanguagesForBlog` now also requires a title, so it can't point at a now-404 URL). Verified: exactly the 13 empty `vova` files are dropped; no titled post is affected.

**2. Defensive breadcrumb generator** (`src/schema/generators.ts`) — belt-and-suspenders for any future empty-title content. `breadcrumbSchema` now trims names, drops blank ones, and renumbers `position` to stay contiguous from 1, so every `ListItem` always carries a non-empty `name`.

## Not included

The empty stub files themselves live in the `milvus-io/community` submodule and should be removed/filled upstream separately. This PR makes milvus.io resilient regardless.

## Verify after deploy

Run the affected URL through the [Rich Results Test](https://search.google.com/test/rich-results) (the route should now 404 / no longer emit a broken breadcrumb), then click **Validate Fix** on the GSC issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)