### PR TITLE
fix(home): hide headline carousel when list is empty

### DIFF
--- a/src/parts/home/headerSection/index.tsx
+++ b/src/parts/home/headerSection/index.tsx
@@ -57,8 +57,9 @@ export default function HomePageHeaderSection(props: {
       )}
     >
       <div className={pageClasses.homeContainer}>
-        <div className={classes.headlinesContainer}>
-          <Swiper
+        {headlines.length > 0 && (
+          <div className={classes.headlinesContainer}>
+            <Swiper
             // install Swiper modules
             modules={showSwiper ? [Navigation, Autoplay, Pagination] : []}
             navigation={{
@@ -117,8 +118,9 @@ export default function HomePageHeaderSection(props: {
                 <RightArrowIcon />
               </button>
             </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
         <h1
           className={clsx(
             'w-full opacity-90 text-center text-slate-950 text-[72px] font-[700] leading-[80px] max-tablet:max-w-[600px] max-tablet:text-[56px] max-tablet:leading-[68px] max-phone:text-[42px] max-phone:leading-[60px] mt-[0px] mb-[12px] mx-auto',


### PR DESCRIPTION
## What

Wrap the homepage headline carousel (`headlinesContainer`) in a `headlines.length > 0` check so the entire block — Swiper, pagination, and nav arrows — is not rendered when there are no headlines.

## Why

When the headlines list read on the homepage is empty, an empty carousel placeholder was still shown above the hero title. Now the block is fully hidden and the `<h1>` hero title moves to the top.

## Notes

- Existing `showSwiper` (`length > 1`) behavior is unchanged: a single headline still renders without pagination/arrows; length `0` now hides the whole block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)