### PR TITLE
fix(footer): stop docs nav from covering the CN WeChat QR code

### DIFF
--- a/src/components/socialMedias/index.module.css
+++ b/src/components/socialMedias/index.module.css
@@ -67,7 +67,9 @@ a.iconButton {
   bottom: calc(100% + 12px);
   left: 50%;
   transform: translateX(-50%);
-  z-index: 10;
+  /* Matches the docs left nav so this popover, being later in the DOM, paints over it
+     on narrow screens, while staying below the sticky header (999). */
+  z-index: 998;
   box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.12);
   border-radius: 12px;
 }

--- a/src/components/socialMedias/index.tsx
+++ b/src/components/socialMedias/index.tsx
@@ -103,12 +103,7 @@ export const SocialMediasCN = (props: {
   ];
 
   return (
-    <div
-      className={clsx(
-        'flex items-center justify-start gap-[12px] relative z-0',
-        root
-      )}
-    >
+    <div className={clsx('flex items-center justify-start gap-[12px]', root)}>
       {CNSocialJson.map(s => {
         if (s.image) {
           return (


### PR DESCRIPTION
## Problem

On the Chinese site, hovering the WeChat icon in the docs footer shows a QR code popover. On narrow screens it was rendered **behind** the docs left nav tree, leaving the QR code unusable.

## Root cause

Not an insufficient z-index — a **stacking context**.

The `SocialMediasCN` root element carried `relative z-0`, which creates a stacking context and traps the entire subtree at level 0. The popover's `z-index: 10` therefore only ranked it against its own siblings; from the outside the whole group was flattened to 0. The docs nav (`.flexibleContainer`) sits at `z-index: 998`, so the nav always won.

## Fix

- Drop `relative z-0` from the `SocialMediasCN` root, removing the stacking context.
- Raise `.qrcodePopover` from `z-index: 10` to `998`.

**Why 998 and not 999:** the header is also `z-index: 999`, and the footer comes later in the DOM. At 999 the popover would tie with the header and win, covering the sticky header — trading one bug for another. At 998 it ties with the nav and wins on DOM order, while staying below the header. The reasoning is in a comment so the value doesn't get "helpfully" bumped later.

## Verification

Driven in a real browser (Playwright) at 1100px on `/docs/zh`. The popover (x=231) genuinely overlaps the nav (right edge 283), so the overlap is hit-tested directly:

| Scenario | Top element at overlap point |
|---|---|
| Before (fix stashed) | nav `treeItemLabel` ❌ |
| After | the popover ✅ |
| Popover ∩ header | header ✅ (not covered) |

Ran the same script with the change stashed and restored, confirming the bug reproduces and that these two edits are what fix it.

Also checked:
- CN homepage footer (same component, no docs nav) — popover still renders correctly.
- `tsc --noEmit` passes.
- EN footer untouched: `SocialMediasCN` is only used in the `isCNSite` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)