### PR TITLE
fix(deps): bump axios to 1.19.0 (clears 10 advisories)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@zilliz/toolkit": "^0.2.7",
     "autoprefixer": "^10.4.27",
-    "axios": "^1.16.0",
+    "axios": "^1.19.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
     "cropperjs": "^1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.14)
       axios:
-        specifier: ^1.16.0
-        version: 1.16.0
+        specifier: ^1.19.0
+        version: 1.19.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2200,6 +2200,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -2310,8 +2314,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3209,6 +3213,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -6916,6 +6924,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -7066,13 +7080,15 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.16.0:
+  axios@1.19.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -8171,6 +8187,13 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   humanize-ms@1.2.1:
     dependencies:


### PR DESCRIPTION
Fixes dependency alerts [217](https://github.com/milvus-io/milvus.io/security/dependabot/217), [218](https://github.com/milvus-io/milvus.io/security/dependabot/218), [219](https://github.com/milvus-io/milvus.io/security/dependabot/219), [220](https://github.com/milvus-io/milvus.io/security/dependabot/220), [221](https://github.com/milvus-io/milvus.io/security/dependabot/221), [223](https://github.com/milvus-io/milvus.io/security/dependabot/223), [224](https://github.com/milvus-io/milvus.io/security/dependabot/224), [225](https://github.com/milvus-io/milvus.io/security/dependabot/225), [227](https://github.com/milvus-io/milvus.io/security/dependabot/227), [228](https://github.com/milvus-io/milvus.io/security/dependabot/228).

## What

Bump `axios` `^1.16.0` → `^1.19.0`, clearing **10 advisories** (1 high, 9 medium) in one change: prototype pollution in config/auth handling, `maxBodyLength` bypasses via HTTP/2 and fetch `ReadableStream` uploads, `formDataToJSON` recursion DoS, `NO_PROXY` bypasses, and inherited-proxy reuse after interceptor cloning.

The advisories are all fixed in 1.18.0, but `^1.18.0` floats to 1.19.0 anyway, so the range declares **1.19.0** — the version actually installed and verified here, rather than one that was never tested.

This is the most broadly reachable of the open alerts: axios is a **direct runtime dependency** used across `src/http/` (`imageSearch`, `submitEmail`, `milvus`, `useCase`, `home`, `index`), plus `next.config.js` and the i18n watcher.

## Behavioral changes checked against our code

1.17–1.19 carry real behavior changes. Each was checked against actual usage:

- **Cross-origin redirects now strip caller-specified sensitive headers** — our instances only set `Content-Type`; no custom auth headers. The `auth` variable in `src/http/milvus.ts` belongs to Octokit, not axios.
- **Malformed `http:`/`https:` URLs without `//` now throw `ERR_INVALID_URL`** — all hardcoded baseURLs are well-formed. See the caveat below.
- **`validateStatus` semantics** — opt-in via `transitional.validateStatusUndefinedResolves`; we set `validateStatus` nowhere.
- **`combineURLs` now strips all trailing slashes** (was: at most two) — verified equivalent for our `create({baseURL}) + get('/path')` pattern; tested `https://api.github.com`, `.../`, and `.../// ` variants, all 200.
- **Sync request-interceptor failures no longer dispatch the request** — our interceptors only pass config through.
- **New runtime dependency**: `https-proxy-agent@^5.0.1`. Also raises the `form-data` floor to `^4.0.6`, consistent with the existing override in `package.json`.

## Source diff review (1.16.0 → 1.19.0)

- `lib/` has 4 new files (`setFormDataHeaders`, `Http2Sessions`, `sanitizeHeaderValue`, node `Buffer`) and no removals; changed files map onto the advisories (`mergeConfig`, `shouldBypassProxy`, `formDataToJSON`, `estimateDataURLDecodedBytes`, `buildFullPath`, `AxiosHeaders`)
- The new URL guard is confirmed narrow: it only matches `/^https?:(?!\/\/)/i`

## Verification

- Production build + sitemap pass
- `next start` smoke test: `/`, `/docs`, `/blog`, `/docs/overview.md`, and `/use-cases` all 200 — `/use-cases` specifically exercises `src/http/useCase.ts`
- Functional test of our exact axios call patterns against a live endpoint (see trailing-slash cases above)

## One caveat worth a reviewer's eye

The build log shows `error-- TypeError: Invalid URL` from `src/http/useCase.ts`. **This is pre-existing and unrelated to the upgrade** — it happens because `NEXT_PUBLIC_CMS_BASE_URL` is unset locally, making the URL `undefined/customer-stories`. Verified empirically: axios 1.16.0 and 1.19.0 both produce an identical `TypeError | ERR_INVALID_URL`, and the same error appears on branches that do not touch axios. It is caught and returns `[]`.

That said, `NEXT_PUBLIC_MSERVICE_URL` and `NEXT_PUBLIC_CMS_BASE_URL` come from GitHub secrets whose values I cannot see. If either is stored **without** the `//` after the scheme, the new guard would now throw where it previously did not. Both would already be malformed today, so this is unlikely — but worth a glance from someone with access to the secrets.

**Not covered**: `pnpm lint` cannot run (`next lint` is deprecated and drops into an interactive setup prompt) and the repo has no `test` script. Both are pre-existing gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)