### PR TITLE
fix(language-selector): opt out of page translation to stop a crash

### DIFF
--- a/src/components/language-selector/LanguageSelector.tsx
+++ b/src/components/language-selector/LanguageSelector.tsx
@@ -183,7 +183,24 @@ export const LanguageSelector: FC<Props> = props => {
   ].filter(option => !option.disabled);
 
   return (
-    <div className={className}>
+    // Every label below is an endonym -- "English", "简体中文", "日本語で". A page
+    // translator rewriting them is wrong on its own terms (a language picker
+    // must name each language in that language), and it also crashes the app:
+    // the translator detaches the value text node and swaps in a <font>, so
+    // React's later unmount hits `span.removeChild(<detached text node>)` and
+    // throws NotFoundError, which the root error boundary turns into
+    // "Application error: a client-side exception has occurred".
+    //
+    // Measured: with an entire page translated (161 text nodes rewritten), this
+    // value node is the *only* one React removes individually -- everywhere else
+    // it deletes an ancestor element and the injected <font> goes along with it
+    // harmlessly. So opting this one widget out is enough.
+    //
+    // `translate="no"` is the HTML attribute; `notranslate` is Google's older
+    // hook. Chrome's built-in translator honours both, and so do the common
+    // extensions. The dropdown needs its own copy because Radix portals it to
+    // document.body, where it does not inherit the wrapper's attribute.
+    <div className={clsx(className, 'notranslate')} translate="no">
       <Select
         value={value}
         onValueChange={onChange}
@@ -209,7 +226,10 @@ export const LanguageSelector: FC<Props> = props => {
           <LanguageIcon className="transition-all" />
           {!hiddenSelectValue && <SelectValue placeholder="Language" />}
         </SelectTrigger>
-        <SelectContent className="z-[1000] shadow-nav-menu mt-[8px]">
+        <SelectContent
+          className="z-[1000] shadow-nav-menu mt-[8px] notranslate"
+          translate="no"
+        >
           <SelectGroup>
             {options.map(option => {
               return (


### PR DESCRIPTION
## 问题

开着页面翻译（Chrome 内置翻译 / 沉浸式翻译等插件）的用户，**进入 docs 路由时页面直接挂掉**：

```
NotFoundError: Failed to execute 'removeChild' on 'Node':
The node to be removed is not a child of this node.
```

不只是控制台报错 —— 根部 ErrorBoundary 会接住它并渲染 `Application error: a client-side exception has occurred`，文档内容完全不显示。

## 根因

翻译器改写文本节点的方式是：把原文本节点摘掉，塞一个装着译文的 `<font>` 进去。React 的 fiber 里还记着那个已脱离的节点，所以下次卸载时执行

```
span.removeChild(<已脱离的 "English" 文本节点>)   →   NotFoundError
```

出错的 `<span style="pointer-events:none">` 是 Radix Select 的 value span，里面那个文本节点就是**语言选择器当前显示的值**。

## 为什么只有这一个节点会崩

给 `Node.prototype.removeChild` 打桩，在整页翻译的情况下测量：

| | |
|---|---|
| 被改写的文本节点 | **161** |
| 导致 React 崩溃的 | **1**（语言选择器的值） |

其余 160 个没事，因为 React 删的是它们的**祖先元素**，插进去的 `<font>` 跟着一起走，无害。只有语言选择器这个值节点会被 React 单独 `removeChild`。

所以只给这一个组件加豁免就够了。

## 改动

```jsx
<div className={clsx(className, 'notranslate')} translate="no">
...
<SelectContent className="... notranslate" translate="no">
```

下拉内容需要单独标一次 —— Radix 把它 portal 到 `document.body`，继承不到外层 div 的属性。

`translate="no"` 是 HTML 规范属性，`notranslate` 是 Google 的老 hook，Chrome 内置翻译和常见插件两者都遵守。

**这个改动本身也是对的，跟 crash 无关**：这些 label 全是本族语名称（`English`、`简体中文`、`日本語で`、`한국어`…），语言选择器把 "English" 显示成 "英语" 本来就是错的。

## 验证

| 场景 | 结果 |
|---|---|
| 修复后 + 翻译器遵守豁免标记 | 157 个节点被翻译、1 个跳过，**0 处 removeChild 不匹配**，`/docs` 正常渲染 |
| 对照组：同样代码，翻译器**无视**标记 | 仍然 1 处不匹配（`English`）—— 说明检测手段有效，不是空跑 |
| 生产环境（修复前） | 1 处不匹配 + 整页 Application error |

复现签名与线上用户上报的完全一致：

```
React 以为的父节点: SPAN  attrs=style="pointer-events: none;"
实际的父节点:      (已脱离文档)
被删的节点:        #text
HTML 片段:         English
```

## 两点说明

1. **这是针对性缓解，不是通用免疫。**"只有语言选择器会被单独删除"是当前组件树的实测属性，不是 React 的保证；以后新组件可能重新引入同样的模式。
2. **依赖翻译器遵守标记。** 彻底免疫只能给 `<html>` 加 `translate="no"` 全站禁翻，对文档站不可接受。

## 与 #2382 的关系

#2382（非英文页面 hydration 失败）**不是**这个 crash 的原因，两者独立。该 PR 的描述已同步更正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)