### PR TITLE
fix(styles): stop font stacks falling back to the browser default font

### DIFF
--- a/src/components/aside/index.module.css
+++ b/src/components/aside/index.module.css
@@ -1,6 +1,6 @@
 
 .rightNavWrapper {
-  font-family: 'Geist';
+  font-family: 'Geist', system-ui, sans-serif;
 
   .btnsGroup {
     padding: 12px 0;
@@ -158,21 +158,21 @@ div.customRootClass {
 
   .customTitleClass {
     @mixin heading3;
-    font-family: 'Geist';
+    font-family: 'Geist', system-ui, sans-serif;
     color: var(--color-dark);
    
   }
 }
 
 p.dialogSubTitle {
-  font-family: 'Geist';
+  font-family: 'Geist', system-ui, sans-serif;
   color: var(--color-dark);
   @mixin paragraph3-regular;
   margin-bottom: 24px;
 }
 
 label.inputLabel {
-  font-family: 'Geist';
+  font-family: 'Geist', system-ui, sans-serif;
   color: var(--color-dark);
   @mixin paragraph6-bold;
   letter-spacing: 0.24px;
@@ -180,7 +180,7 @@ label.inputLabel {
 }
 
 input.customInputField {
-  font-family: 'Geist';
+  font-family: 'Geist', system-ui, sans-serif;
   @mixin paragraph4-regular;
   margin-top: 8px;
 }

--- a/src/components/cookieConsent/index.module.css
+++ b/src/components/cookieConsent/index.module.css
@@ -27,13 +27,13 @@
     @mixin paragraph4;
     color: var(--color-black1);
     margin-bottom: 6px;
-    font-family: Geist !important;
+    font-family: 'Geist', system-ui, sans-serif !important;
   }
 
   p {
     @mixin paragraph6-regular;
     color: var(--color-black2);
-    font-family: Geist !important;
+    font-family: 'Geist', system-ui, sans-serif !important;
   }
 }
 .buttonsWrapper {
@@ -51,7 +51,7 @@
   margin: 0 !important;
   padding: 8px 12px !important;
   border-radius: 6px !important;
-  font-family: Geist !important;
+  font-family: 'Geist', system-ui, sans-serif !important;
 
   &:hover {
     opacity: 0.7;

--- a/src/components/copyCodeButton/index.module.css
+++ b/src/components/copyCodeButton/index.module.css
@@ -12,7 +12,7 @@
 }
 
 .installPy {
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;

--- a/src/components/customButton/index.module.css
+++ b/src/components/customButton/index.module.css
@@ -1,6 +1,6 @@
 
 .linkButton {
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   @mixin resetNativeButton;
   @mixin paragraph3;
   display: flex;

--- a/src/components/customTabs/index.module.css
+++ b/src/components/customTabs/index.module.css
@@ -1,6 +1,6 @@
 
 .tabsOuterWrapper {
-  font-family: Geist;
+  font-family: 'Geist', system-ui, sans-serif;
   position: relative;
 }
 

--- a/src/components/mdx/rest-space/Admonition.module.css
+++ b/src/components/mdx/rest-space/Admonition.module.css
@@ -63,7 +63,7 @@
 .admonition li > code {
   font-size: 14px;
   line-height: 1.4rem;
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   color: #1493cc;
   display: inline-block;
   font-weight: 600;

--- a/src/components/search/agloia.module.css
+++ b/src/components/search/agloia.module.css
@@ -44,7 +44,7 @@
       }
     }
     :global(.DocSearch-Container) * {
-      font-family: Geist;
+      font-family: 'Geist', system-ui, sans-serif;
     }
   }
 }

--- a/src/components/treeView/ExpansionTreeView.module.css
+++ b/src/components/treeView/ExpansionTreeView.module.css
@@ -18,7 +18,7 @@
   font-size: 16px;
   line-height: 24px;
   color: var(--color-grey-01);
-  font-family: Geist;
+  font-family: 'Geist', system-ui, sans-serif;
   white-space: nowrap;
   overflow: hidden;
 

--- a/src/parts/blogs/zillizAdv/index.module.css
+++ b/src/parts/blogs/zillizAdv/index.module.css
@@ -24,7 +24,7 @@
     font-weight: 500;
     line-height: 1.5;
     text-transform: uppercase;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
   }
 
   &-title {
@@ -44,7 +44,7 @@
       list-style: none;
       display: flex;
       align-items: center;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
 
       &:not(:first-of-type) {
         margin-top: 8px;

--- a/src/parts/docs/docHome/index.module.css
+++ b/src/parts/docs/docHome/index.module.css
@@ -20,7 +20,7 @@
 }
 
 .docHomeHtmlWrapper {
-  font-family: 'Geist';
+  font-family: 'Geist', system-ui, sans-serif;
   display: block;
   margin-right: 0;
   max-width: calc(var(--doc-content-width) + var(--doc-aside-width));

--- a/src/parts/home/codeExampleSection/index.module.css
+++ b/src/parts/home/codeExampleSection/index.module.css
@@ -1,7 +1,7 @@
 
 .codeExampleSection {
   padding-top: 100px;
-  font-family: Geist;
+  font-family: 'Geist', system-ui, sans-serif;
   content-visibility: auto;
   contain-intrinsic-size: 480px;
 
@@ -53,7 +53,7 @@
 
       button {
         text-transform: uppercase !important;
-        font-family: 'Geist Mono';
+        font-family: 'Geist Mono', monospace;
       }
     }
   }
@@ -73,7 +73,7 @@
       padding-bottom: 12px;
 
       code {
-        font-family: 'Geist Mono';
+        font-family: 'Geist Mono', monospace;
         color: #fff;
         font-size: 14px;
         line-height: 20px;

--- a/src/parts/home/deploySection/index.module.css
+++ b/src/parts/home/deploySection/index.module.css
@@ -127,7 +127,7 @@
     }
     .dbAdvantage {
       @mixin paragraph2;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
       margin-bottom: 12px;
       height: 54px;
     }
@@ -135,7 +135,7 @@
     .dbFeatures {
       list-style-type: disc;
       padding-left: 20px;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
 
       li {
         @mixin paragraph3-regular;
@@ -187,7 +187,7 @@
     border: 1px solid var(--color-black4);
     max-width: 479px;
     margin: 0 auto;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     font-weight: 500;
 
     a {

--- a/src/parts/home/developSection/index.module.css
+++ b/src/parts/home/developSection/index.module.css
@@ -19,7 +19,7 @@
     p {
       @mixin paragraph2-regular;
       color: var(--color-black2);
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
     }
   }
 

--- a/src/parts/home/headerSection/index.module.css
+++ b/src/parts/home/headerSection/index.module.css
@@ -103,7 +103,7 @@ a.startButton {
     }
   }
   .headlineTag {
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     flex-grow: 0;
     @mixin paragraph6;
     border-radius: 4px;
@@ -113,7 +113,7 @@ a.startButton {
   }
 
   .headlineLink {
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     @mixin paragraph6-regular;
     color: var(--color-black2);
 

--- a/src/parts/home/lovedSection/index.module.css
+++ b/src/parts/home/lovedSection/index.module.css
@@ -32,7 +32,7 @@
     border: 1px solid var(--color-black4);
     padding: 30px;
     background-color: #fff;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     a {
       display: flex;
       flex-direction: column;

--- a/src/parts/home/subscribeSection/index.module.css
+++ b/src/parts/home/subscribeSection/index.module.css
@@ -60,14 +60,14 @@
   }
 
   .subscribeTitle {
-    font-family: Geist;
+    font-family: 'Geist', system-ui, sans-serif;
     font-size: 32px;
     font-style: normal;
     font-weight: 600;
     line-height: 1.4;
   }
   .subscribeDesc {
-    font-family: Geist Mono;
+    font-family: 'Geist Mono', monospace;
     font-size: 14px;
     line-height: 1.4;
     margin-top: 8px;
@@ -105,7 +105,7 @@
       font-size: 14px;
       font-weight: 400;
       line-height: 1.3!important;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
     }
   
     &-input-message {

--- a/src/parts/home/tryFreeSection/index.module.css
+++ b/src/parts/home/tryFreeSection/index.module.css
@@ -82,7 +82,7 @@
       color: var(--color-black1);
       text-align: center;
       margin-bottom: 24px;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
 
       @media (--tablet), (--phone) {
         font-size: 14px;

--- a/src/parts/home/vdbSection/index.module.css
+++ b/src/parts/home/vdbSection/index.module.css
@@ -80,7 +80,7 @@
         p {
           @mixin paragraph4-regular;
           color: var(--color-black2);
-          font-family: 'Geist Mono';
+          font-family: 'Geist Mono', monospace;
         }
       }
     }
@@ -110,7 +110,7 @@
     border-radius: 12px;
     border: 1px solid var(--color-black4);
     background: #fff;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     font-weight: 500;
 
     a {

--- a/src/parts/sizingCommon/index.module.css
+++ b/src/parts/sizingCommon/index.module.css
@@ -15,17 +15,17 @@
 }
 
 .commonLabel {
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   @mixin paragraph4-bold;
 }
 
 .selectItem {
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   @mixin paragraph6;
 }
 
 .selectTrigger {
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   @mixin paragraph6-regular;
   padding: 9px 12px;
   height: 36px;
@@ -239,7 +239,7 @@ div.averageLabel {
 }
 
 .resultContainer {
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
 
   .commonKeyLabel {
     @mixin paragraph6-regular;

--- a/src/styles/banner.module.css
+++ b/src/styles/banner.module.css
@@ -196,7 +196,7 @@
       border-radius: 100px;
       border: transparent;
 
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
       font-style: normal;
       font-weight: 500;
       font-size: 16px;
@@ -247,7 +247,7 @@
       color: white;
     }
     .num {
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
       font-weight: 400;
       font-size: 32px;
       line-height: 42.2px;

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -83,7 +83,7 @@
 
   .trending {
     color: #ffaa00;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     font-size: 14px;
     font-weight: 600;
     line-height: 1.4;
@@ -218,7 +218,7 @@
     font-weight: 400;
     line-height: 1.5;
     color: var(--color-black2);
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
   }
 
   &-form {
@@ -257,7 +257,7 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 1.3 !important;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
   }
 
   &-input-message {
@@ -343,7 +343,7 @@
   padding: 0 12px;
   height: 40px;
   box-sizing: border-box;
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   transition: all 0.1s ease;
 
   &:focus-within {
@@ -482,7 +482,7 @@
     font-weight: 400;
     line-height: 1.5;
     color: var(--color-black2);
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
   }
 
   &-icon {
@@ -516,7 +516,7 @@
     font-weight: 500;
     line-height: 1.5;
     text-transform: uppercase;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
   }
 
   &-title {
@@ -536,7 +536,7 @@
       list-style: none;
       display: flex;
       align-items: center;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
 
       &:not(:first-of-type) {
         margin-top: 8px;
@@ -629,7 +629,7 @@
       font-size: 18px;
       font-weight: 600;
       line-height: 1.4;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
     }
 
     &-title {
@@ -637,7 +637,7 @@
       font-weight: 400;
       line-height: 1.5;
       color: var(--color-black2);
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
     }
   }
 }
@@ -652,7 +652,7 @@
   font-weight: 600;
   letter-spacing: 1.4px;
   color: var(--color-black2);
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
 
   &-tags {
     text-transform: uppercase;

--- a/src/styles/community.module.css
+++ b/src/styles/community.module.css
@@ -2,7 +2,7 @@
 .communityPageContainer {
   margin: 0 auto;
   padding-bottom: 40px;
-  font-family: 'Geist';
+  font-family: 'Geist', system-ui, sans-serif;
   background-color: var(--color-white1);
 }
 
@@ -110,7 +110,7 @@
 
       .desc {
         @mixin paragraph4-regular;
-        font-family: 'Geist Mono';
+        font-family: 'Geist Mono', monospace;
         margin-bottom: 20px;
         max-width: 600px;
 
@@ -121,7 +121,7 @@
 
       .linkBtn {
         @mixin paragraph4;
-        font-family: 'Geist Mono';
+        font-family: 'Geist Mono', monospace;
         color: #fff;
         border-color: #fff;
         background-color: transparent;
@@ -157,7 +157,7 @@
 
   .sectionDesc {
     @mixin paragraph3-regular;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
 
     margin: 0 auto 40px;
     max-width: 880px;
@@ -192,12 +192,12 @@
       }
 
       .label {
-        font-family: 'Geist Mono';
+        font-family: 'Geist Mono', monospace;
         @mixin paragraph2-bold;
       }
 
       .desc {
-        font-family: 'Geist Mono';
+        font-family: 'Geist Mono', monospace;
         @mixin paragraph4-regular;
       }
     }
@@ -223,7 +223,7 @@
     .linkBtn {
       @mixin paragraph4;
       flex: 1;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
       display: flex;
       padding: 11px 28px;
       justify-content: center;

--- a/src/styles/docsStyle.css
+++ b/src/styles/docsStyle.css
@@ -174,7 +174,7 @@ html[lang='ar'] {
   code {
     font-size: 14px;
     line-height: 1.4rem;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     background-color: var(--code-bg-color);
     border-radius: 4px;
     padding: 0 8px;
@@ -236,7 +236,7 @@ html[lang='ar'] {
       display: block;
       font-size: 14px;
       line-height: 20px;
-      font-family: 'Geist Mono';
+      font-family: 'Geist Mono', monospace;
       border: none;
       background-color: transparent;
       font-weight: 400;

--- a/src/styles/faq.module.css
+++ b/src/styles/faq.module.css
@@ -15,7 +15,7 @@
     color: var(--color-black2);
     max-width: 1074px;
     margin: 0 auto 40px;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
   }
 
   .inputWrapper {

--- a/src/styles/mixins.css
+++ b/src/styles/mixins.css
@@ -5,7 +5,7 @@
   cursor: pointer;
   height: 58px;
   padding: 20px 40px;
-  font-family: 'Roboto Mono';
+  font-family: 'Geist Mono', monospace;
   font-size: 16px;
   line-height: 18px;
   border: 0;
@@ -20,7 +20,7 @@
 @define-mixin buttonSm {
   border-radius: 40px;
   cursor: pointer;
-  font-family: 'Roboto Mono';
+  font-family: 'Geist Mono', monospace;
   line-height: 18px;
   border: 0;
   height: 38px;

--- a/src/styles/restful.module.css
+++ b/src/styles/restful.module.css
@@ -73,7 +73,7 @@
   p > code {
     font-size: 14px;
     line-height: 1.4rem;
-    font-family: 'Geist Mono';
+    font-family: 'Geist Mono', monospace;
     background-color: #f0f4f9;
     color: #1493cc;
     display: inline-block;

--- a/src/styles/sizingTool.module.css
+++ b/src/styles/sizingTool.module.css
@@ -6,7 +6,7 @@
 .sizingToolContainer {
   padding-top: 80px;
   padding-bottom: 40px;
-  font-family: 'Geist Mono';
+  font-family: 'Geist Mono', monospace;
   color: var(--color-black1);
 
   .titleContainer {
@@ -26,7 +26,7 @@
       a {
         @mixin heading2;
 
-        font-family: 'Geist';
+        font-family: 'Geist', system-ui, sans-serif;
         color: #000;
         display: block;
         max-width: 600px;


### PR DESCRIPTION
## What

62 `font-family` declarations across 27 files named `'Geist'` or `'Geist Mono'` with **no generic family** at the end of the stack. This PR appends one to each, and replaces a reference to a font that was never loaded.

## Why

When every family in a stack fails to match, CSS does **not** fall back to the inherited value — the browser drops to its own default font setting. On Windows that means Times New Roman for Latin text and SimSun (宋体) for Simplified Chinese. Two ways to hit it today:

1. **The woff2 fails to load** — anything styled with a bare `font-family: 'Geist Mono';` goes straight to the browser default rather than to a monospace face.
2. **CJK and Arabic pages** — `src/styles/fonts.css` only declares `latin`, `latin-ext`, `vietnamese`, `cyrillic` and `cyrillic-ext` unicode-ranges. Chinese, Japanese, Korean and Arabic characters fall outside all of them, so on the 5 CJK/RTL locales those elements had no matching family at all. Body text was fine (`reset.css` already ends its stack with `sans-serif`); buttons, code blocks and labels were not.

Separately, the shared button mixins (`src/styles/mixins.css:8,23`) asked for `'Roboto Mono'`, which has **no `@font-face` anywhere in the repo** and no fallback either. The `public/fonts/RobotoMono-*.woff2` files exist but nothing declares them. So the banner's primary/secondary buttons rendered in the browser default serif font on every machine without Roboto Mono installed locally. They now use the site's own mono face.

## Notes for review

- **No CJK family names in the stacks, on purpose.** The site serves `ja`, `ko` and `zh-hant`; pinning something like `PingFang SC` or `Microsoft YaHei` would render Japanese and Korean text with Chinese glyph variants. Browser default-font settings are already per-script, so a plain generic family resolves correctly per content language.
- **The `@font-face` blocks in `fonts.css` are untouched.** The bare `font-family` there names the family being defined, not a lookup.
- **This is a visible change, not a no-op.** The banner buttons go from browser-default serif to Geist Mono — that is the fix, but it is worth eyeballing against the design.
- The ~30 declarations that already ended in `monospace` were left alone; they were never broken.

## Test plan

- [x] `postcss` compiles `mixins.css`, `banner.module.css`, `reset.css`, `fonts.css` and the touched module CSS with the project config; the button mixin expands to `font-family: 'Geist Mono', monospace;`
- [x] Diff is 64 insertions / 64 deletions — 1:1 line replacements only, no structural changes
- [ ] Eyeball the homepage banner buttons and a `/zh` docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)