### PR TITLE
feat(sizing): add a GPU sizing tab to /tools/sizing

### DIFF
--- a/gpu-sizing-spec.md
+++ b/gpu-sizing-spec.md
@@ -1,0 +1,171 @@
+# GPU Sizing 工具：入参与结果展示规格
+
+> 适用范围：`tools/sizing` 页面的 GPU 估算能力。
+>
+> 算法来源：内核提供的 `gpu-sizing-demo(1).html`（第二版）。本文只记录**能从该 demo 的自身逻辑闭合推导出来**的部分，未做任何外部联想。
+>
+> 已落地代码：`src/utils/sizingToolGpu.ts`、`src/types/sizingGpu.ts`、`src/consts/sizingGpu.ts`（纯函数，已通过 803 例对拍验证，0 不一致；UI 尚未接入）。
+
+---
+
+## 一、入参
+
+### A. 数据规模
+
+| 字段                         | 控件           | 范围 / 选项                   | 默认 | 用途                                                           |
+| ---------------------------- | -------------- | ----------------------------- | ---- | -------------------------------------------------------------- |
+| `num` 向量条数               | Range + 输入框 | 0.001 – 10000（单位 Million） | 1    | 总量 → 段数                                                    |
+| `d` 向量维度                 | Range + 输入框 | 2 – 32768                     | 768  | 行宽、所有显存公式                                             |
+| `withScalar` 含标量字段      | Switch         | —                             | 关   | 展开下一项                                                     |
+| `scalarAvg` 单行平均标量字节 | 输入框（Byte） | ≥ 0                           | 0    | 只进 raw data 和 host 内存，**不进显存、不进 segmentRowCount** |
+
+### B. 索引参数（随索引类型切换显隐）
+
+| 字段                                        | 控件   | 范围                                                            | 默认              | 出现在           |
+| ------------------------------------------- | ------ | --------------------------------------------------------------- | ----------------- | ---------------- |
+| `indexType`                                 | Select | `GPU_BRUTE_FORCE` / `GPU_IVF_FLAT` / `GPU_IVF_PQ` / `GPU_CAGRA` | `GPU_BRUTE_FORCE` | 全部             |
+| `nlist`                                     | 输入框 | 1 – 65536                                                       | 128               | IVF_FLAT、IVF_PQ |
+| `trainFraction`（kmeans_trainset_fraction） | 输入框 | 0.01 – 1，step 0.05                                             | 0.5               | IVF_FLAT、IVF_PQ |
+| `pqDim`（m / pq_dim）                       | 输入框 | 0 – 32768，**0 = cuVS Auto**                                    | 0                 | 仅 IVF_PQ        |
+| `pqBits`（nbits）                           | Select | 4 / 5 / 6 / 7 / 8                                               | 8                 | 仅 IVF_PQ        |
+| `graphDegree`                               | 输入框 | 1 – 1024                                                        | 64                | 仅 CAGRA         |
+| `intermediateDegree`                        | 输入框 | 1 – 2048                                                        | 128               | 仅 CAGRA         |
+
+`GPU_BRUTE_FORCE` 无任何可调参数——选中后这一块整体收起。
+
+各索引真正进公式的参数见 `GPU_INDEX_PARAM_KEYS`（`src/consts/sizingGpu.ts`）；不属于当前索引的参数会保留默认值但不参与计算，保证切换索引时表单形状稳定。
+
+### C. 部署
+
+| 字段                   | 控件     | 选项                 | 默认       |
+| ---------------------- | -------- | -------------------- | ---------- |
+| `segSize` Segment 大小 | Select   | 512 / 1024 / 2048 MB | 1024       |
+| `mode` 部署形态        | 两张卡片 | Standalone / Cluster | Standalone |
+
+### D. 校验规则
+
+按 demo 的原始判定顺序，命中即中断并展示提示（对应 `GpuValidationErrorEnum`）：
+
+1. `InvalidNumber` — 非有限数 / 负数，或 `num <= 0`、`d < 2`、`segSize <= 0`
+2. `NlistOutOfRange` — IVF 系列 `nlist` 越界
+3. `TrainFractionOutOfRange` — IVF 系列 `trainFraction` 不在 `(0, 1]`
+4. `PqDimOutOfRange` — IVF_PQ 的 `pqDim` 不在 `[1, d]`（自动解析后）
+5. `PqCodeNotByteAligned` — IVF_PQ 的 `pqDim × pqBits` 不是 8 的整数倍
+6. `IntermediateDegreeTooSmall` — CAGRA 的 `intermediateDegree < graphDegree`
+
+### E. 现有 CPU 工具有、但 GPU demo 没有的（待定）
+
+- **mmap offloading 勾选框** —— demo 完全没有。标量卸载到磁盘对显存无影响，但会影响 host 内存
+- **依赖组件选择（Pulsar / Kafka / Woodpecker）** —— demo 没有，因此也没有 etcd / MinIO / MQ 的配置输出
+- **Standalone 自动降级逻辑** —— CPU 工具在 raw data 超过阈值时自动切 Cluster 并禁用 Standalone 卡片；demo 是纯手选
+
+---
+
+## 二、结果展示：三层结构
+
+### 第 1 层：结论区（对应现有 "Approximate Capacity"）
+
+| 展示项             | 字段            | 说明                                                                   |
+| ------------------ | --------------- | ---------------------------------------------------------------------- |
+| Raw Data Size      | `rawDataSize`   | 向量 + 标量原始大小                                                    |
+| CPU Loading Memory | `memorySize`    | 沿用现有 FLAT 公式 `(向量原始 + 2 × 段大小) × 1.15 + 标量`             |
+| **GPU Memory**     | `gpuMemorySize` | 主结论。附注：「当前上限由 {build / resident} 决定，再保留 1.5× 余量」 |
+
+### 第 2 层：计算过程（对应 demo 的 Core calculation）
+
+建议做成可折叠、默认展开——GPU 估算比 CPU 更需要向用户交代推导过程。
+
+| 展示项              | 字段                                       | 示例渲染                                                                                                  |
+| ------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| 单行字节            | 由 `d` 推                                  | `768 × 4 = 3,072 Bytes`                                                                                   |
+| 单段行数            | `segmentRowCount`                          | `1024 MiB ÷ 3,072 = 349,525 vectors`                                                                      |
+| 段数                | `segmentCount`                             | `ceil(1,000,000 ÷ 349,525) = 3`                                                                           |
+| 生效索引参数        | `effectiveIndexParams`                     | 展示**钳制 / 自动解析后**的值：`nlist` 被 `min(nlist, 段行数)` 压过、`pqDim = 0` 被 cuVS 规则解析成实际值 |
+| PQ 单向量编码字节   | `segmentIndexMemory.codeBytes`             | 仅 IVF_PQ：`ceil(m × pq_bits ÷ 8)`                                                                        |
+| 单段索引公式 + 分项 | `segmentIndexMemory`                       | 分项 `dataset / norms / lists / centers / centerNorms / graph`，随索引类型不同                            |
+| 单段索引数据量      | `segmentIndexMemory.total`                 |                                                                                                           |
+| 构建临时显存        | `segmentBuildTemporaryMemory`              | IVF 是训练集，CAGRA 是中间图，BRUTE_FORCE 为 0                                                            |
+| **Build 峰值**      | `buildMemorySize`                          | 单段索引 + 临时                                                                                           |
+| **Resident 常驻**   | `residentMemorySize`                       | 单段索引 × 段数                                                                                           |
+| 生命周期最大值      | `lifecycleMaxMemorySize` / `limitingStage` | 两者取大                                                                                                  |
+
+单段索引数据公式（`gpuIndexMemoryCalculator`）：
+
+| 索引              | 公式                                                               |
+| ----------------- | ------------------------------------------------------------------ |
+| `GPU_BRUTE_FORCE` | `N × D × 4 + N × 4`                                                |
+| `GPU_IVF_FLAT`    | `N × (D × 4 + 8) + nlist × D × 4 + nlist × 4`                      |
+| `GPU_IVF_PQ`      | `N × (ceil(pq_dim × pq_bits ÷ 8) + 8) + nlist × D × 4 + nlist × 4` |
+| `GPU_CAGRA`       | `N × D × 4 + N × graph_degree × 4`                                 |
+
+构建临时显存（`gpuBuildTemporaryMemoryCalculator`）：
+
+| 索引              | 公式                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| IVF_FLAT / IVF_PQ | `N_train × (D × 4 + 4)`，其中 `N_train = floor(N段 × trainFraction)` |
+| CAGRA             | `N段 × intermediate_graph_degree × 4`                                |
+| BRUTE_FORCE       | `0`                                                                  |
+
+> **结构性事实（值得在 UI 上体现）**：Build 分支能否在多段场景胜出，取决于「临时量 vs 单段索引数据量」，而这**因索引而异**：
+>
+> | 索引              | 段数 ≥ 2 时 Build 能否胜出 | 原因                                                                                                 |
+> | ----------------- | -------------------------- | ---------------------------------------------------------------------------------------------------- |
+> | `GPU_BRUTE_FORCE` | 不能                       | 临时量恒为 0                                                                                         |
+> | `GPU_IVF_FLAT`    | 不能                       | `临时量 = trainRows × (4d+4) ≤ N × (4d+4) < N × (4d+8) ≤ 索引数据量`                                 |
+> | `GPU_IVF_PQ`      | **能**                     | 训练集是未压缩的 float32 向量，而索引数据是压缩后的 PQ code——`0.5 × (4d+4)` 轻易超过 `codeBytes + 8` |
+> | `GPU_CAGRA`       | **能**                     | 当 `intermediate_graph_degree > (d + graph_degree) × (段数 − 1)` 时成立                              |
+>
+> 803 例对拍中实测：`ivfPq | build | 多段` 出现 49 次，`cagra | build | 多段` 出现 1 次，而 `bf` / `ivfFlat` 一次都没有。
+>
+> 所以 UI 提示不能写成「只有单段才可能 build 胜出」，应当直接以 `limitingStage` 为条件。
+
+### 第 3 层：节点配置（对应现有 "Milvus Components"）
+
+**Standalone** —— 一行：`standaloneNodeConfig` 的 `cpu / memory / count`，外加 `gpuMemory`（= 第 1 层的 GPU Memory 全量）。
+
+**Cluster** —— 五行，每行 `CPU / 内存 / 数量`，其中两行带显存：
+
+| 节点            | 显存                               | 备注                         |
+| --------------- | ---------------------------------- | ---------------------------- |
+| Query Node      | `residentMemorySize × 1.5 ÷ count` | 常驻分摊到每张卡             |
+| Data Node       | `buildMemorySize × 1.5`            | 构建端峰值                   |
+| Proxy           | —                                  |                              |
+| Mix Coord       | —                                  |                              |
+| **Stream Node** | —                                  | demo 新增，现有 CPU 工具没有 |
+
+> ⚠️ 与现有 CPU 工具的节点表**不一致**：demo 去掉了 Index Node、加了 Stream Node，档位数值也自成一套。两套表是否统一需要确认。
+
+---
+
+## 三、现有工具有、GPU 侧目前空缺的
+
+- **Setup overview（总 CPU / 总内存）** —— 可从节点配置聚合得到，另可加一行「总显存」
+- **依赖组件（etcd / MinIO / Pulsar-Kafka）** —— demo 完全没算，Cluster 模式下这块是空的
+- **安装命令 / helm & operator yaml 下载** —— GPU 版 yaml 需要带 GPU resource limit，现有生成器不支持
+
+---
+
+## 四、待决策项
+
+1. **节点表**：沿用 demo 那套（去 Index Node、加 Stream Node），还是对齐现有 CPU 工具？
+2. **依赖组件和安装引导**：GPU 页面是否保留？保留的话依赖组件算法需复用 CPU 侧。
+3. **落地形态**：新开 `/tools/sizing-gpu` 页面，还是在现有 sizing 页面加 CPU / GPU 切换？
+
+这三条确定后即可推进 `config.ts` + `formSection` + `resultSection`。
+
+---
+
+## 五、仍需向内核确认的算法问题
+
+以下在两版材料中均无出处，代码里已提成具名常量，拿到答案后是一行改动：
+
+| #   | 问题                                                                                                     |
+| --- | -------------------------------------------------------------------------------------------------------- |
+| A   | 峰值究竟是 `max(build, resident)`，还是 `resident + buildTemp × 并发度`？Standalone 下尤其存疑           |
+| B   | Workspace Pool 的 1 GB 下限目前**完全没有计入**                                                          |
+| C   | `T(n_queries)` 检索工作区按 0 处理，没有 topk / nprobe / 并发度入参                                      |
+| D   | `GPU_MEMORY_SAFETY_FACTOR = 1.5` 无出处，且未覆盖 RMM 池非连续扩张导致的碎片化 OOM                       |
+| E   | IVF-PQ 的 codebook 项在第一版 demo 中存在、第二版被删除，需确认是 per-subspace 还是 per-cluster          |
+| F   | segment → GPU / 显卡的映射关系未定义；无显卡容量表，也无 `gpu.initMemSize` / `gpu.maxMemSize` 的配置建议 |
+| G   | 节点档位表与 Stream Node 零出处，且与现网 CPU 工具存在分歧                                               |
+| H   | 仅支持 float32；`segmentRowCount` 忽略标量字节；Vamana 未暴露故省略；host 与 GPU 双份常驻未经确认        |

--- a/src/components/sizing/index.ts
+++ b/src/components/sizing/index.ts
@@ -2,3 +2,4 @@ export * from './sizingInput';
 export * from './sizingRange';
 export * from './sizingSwitch';
 export * from './threeOptionSwitch';
+export * from './sizingTabs';

--- a/src/components/sizing/sizingTabs/index.module.css
+++ b/src/components/sizing/sizingTabs/index.module.css
@@ -1,0 +1,60 @@
+.tabs {
+  display: inline-flex;
+  padding: 4px;
+  background: #f2f4f7;
+  border-radius: 10px;
+  gap: 4px;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Helvetica Neue',
+    'PingFang SC',
+    'Microsoft YaHei',
+    sans-serif;
+}
+
+.tab {
+  padding: 9px 18px;
+  border-radius: 7px;
+  border: 0;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  background: transparent;
+  color: #667085;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.tabActive {
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 1px 3px rgba(16, 24, 40, 0.12);
+}
+
+.tabBadge {
+  margin-left: 8px;
+  background: #e0f5ff;
+  color: #0079b0;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  vertical-align: 1px;
+}
+
+.hint {
+  margin-top: 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #667085;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Helvetica Neue',
+    'PingFang SC',
+    'Microsoft YaHei',
+    sans-serif;
+}

--- a/src/components/sizing/sizingTabs/index.tsx
+++ b/src/components/sizing/sizingTabs/index.tsx
@@ -1,0 +1,63 @@
+import clsx from 'clsx';
+import classes from './index.module.css';
+
+export interface SizingTabOption<T extends string> {
+  value: T;
+  label: string;
+  badge?: string;
+}
+
+interface SizingTabsProps<T extends string> {
+  options: SizingTabOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  hint?: string;
+  className?: string;
+  /** Shared prefix for the tab/panel ids, so panels can point back at a tab. */
+  idPrefix?: string;
+}
+
+export const sizingTabId = (idPrefix: string, value: string) =>
+  `${idPrefix}-tab-${value}`;
+
+export const sizingTabPanelId = (idPrefix: string, value: string) =>
+  `${idPrefix}-panel-${value}`;
+
+export function SizingTabs<T extends string>(props: SizingTabsProps<T>) {
+  const {
+    options,
+    value,
+    onChange,
+    hint,
+    className,
+    idPrefix = 'sizing',
+  } = props;
+
+  return (
+    <div className={className}>
+      <div className={classes.tabs} role="tablist">
+        {options.map(option => (
+          <button
+            key={option.value}
+            id={sizingTabId(idPrefix, option.value)}
+            type="button"
+            role="tab"
+            aria-selected={option.value === value}
+            aria-controls={sizingTabPanelId(idPrefix, option.value)}
+            tabIndex={option.value === value ? 0 : -1}
+            className={clsx(classes.tab, {
+              [classes.tabActive]: option.value === value,
+            })}
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+            {option.badge && (
+              <span className={classes.tabBadge}>{option.badge}</span>
+            )}
+          </button>
+        ))}
+      </div>
+      {hint && <div className={classes.hint}>{hint}</div>}
+    </div>
+  );
+}

--- a/src/consts/sizingGpu.ts
+++ b/src/consts/sizingGpu.ts
@@ -1,0 +1,276 @@
+import {
+  GpuIndexTypeEnum,
+  GpuValidationErrorEnum,
+  IGpuIndexMemory,
+  IGpuIndexParams,
+  ModeEnum,
+  SegmentSizeEnum,
+} from '@/types/sizingGpu';
+
+export const ONE_MILLION = Math.pow(10, 6);
+
+/** Head-room applied to the host loading memory, same as the CPU sizing tool. */
+export const CPU_LOADING_SAFETY_FACTOR = 1.15;
+/** Head-room applied to the GPU lifecycle maximum. */
+export const GPU_MEMORY_SAFETY_FACTOR = 1.5;
+
+export const FLOAT_BYTES = 4;
+/** sizeof(IdxT) for IVF inverted lists (int64_t). */
+export const IVF_ID_BYTES = 8;
+/** sizeof(IdxT) for the CAGRA adjacency list (uint32_t). */
+export const GRAPH_ID_BYTES = 4;
+
+/** `m` / `pq_dim` sentinel meaning "let cuVS pick the value". */
+export const PQ_DIM_AUTO = 0;
+
+export const VECTOR_RANGE_CONFIG = {
+  min: 0.001,
+  max: 10000,
+  defaultValue: 1,
+  domain: [0, 25, 50, 75, 100],
+  range: [1, 10, 100, 1000, 10000],
+};
+
+export const DIMENSION_RANGE_CONFIG = {
+  min: 2,
+  max: 32768,
+  defaultValue: 768,
+  domain: [0, 25, 50, 75, 100],
+  range: [2, 128, 768, 1536, 32768],
+};
+
+export const N_LIST_RANGE_CONFIG = {
+  min: 1,
+  max: 65536,
+  defaultValue: 128,
+  domain: [0, 10, 20, 40, 70, 100],
+  range: [1, 16, 128, 4096, 16384, 65536],
+};
+
+export const TRAIN_FRACTION_RANGE_CONFIG = {
+  min: 0.01,
+  max: 1,
+  step: 0.05,
+  defaultValue: 0.5,
+};
+
+export const PQ_DIM_RANGE_CONFIG = {
+  min: 0,
+  max: 32768,
+  defaultValue: PQ_DIM_AUTO,
+};
+
+export const GRAPH_DEGREE_RANGE_CONFIG = {
+  min: 1,
+  max: 1024,
+  defaultValue: 64,
+  domain: [0, 25, 50, 75, 100],
+  range: [1, 8, 64, 256, 1024],
+};
+
+export const INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG = {
+  min: 1,
+  max: 2048,
+  defaultValue: 128,
+  domain: [0, 25, 50, 75, 100],
+  range: [1, 16, 128, 512, 2048],
+};
+
+export const PQ_BITS_OPTIONS = [4, 5, 6, 7, 8].map(value => ({
+  label: `${value}`,
+  value,
+}));
+export const PQ_BITS_DEFAULT_VALUE = 8;
+
+export const DEFAULT_GPU_INDEX_PARAMS: IGpuIndexParams = {
+  nlist: N_LIST_RANGE_CONFIG.defaultValue,
+  trainFraction: TRAIN_FRACTION_RANGE_CONFIG.defaultValue,
+  pqDim: PQ_DIM_RANGE_CONFIG.defaultValue,
+  pqBits: PQ_BITS_DEFAULT_VALUE,
+  graphDegree: GRAPH_DEGREE_RANGE_CONFIG.defaultValue,
+  intermediateDegree: INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG.defaultValue,
+};
+
+/** Index parameters that actually reach the memory formulas, per index type. */
+export const GPU_INDEX_PARAM_KEYS: Record<
+  GpuIndexTypeEnum,
+  (keyof IGpuIndexParams)[]
+> = {
+  [GpuIndexTypeEnum.GPU_BRUTE_FORCE]: [],
+  [GpuIndexTypeEnum.GPU_IVF_FLAT]: ['nlist', 'trainFraction'],
+  [GpuIndexTypeEnum.GPU_IVF_PQ]: ['nlist', 'pqDim', 'pqBits', 'trainFraction'],
+  [GpuIndexTypeEnum.GPU_CAGRA]: ['graphDegree', 'intermediateDegree'],
+};
+
+export const GPU_INDEX_TYPE_OPTIONS = [
+  {
+    label: 'GPU_BRUTE_FORCE',
+    value: GpuIndexTypeEnum.GPU_BRUTE_FORCE,
+  },
+  {
+    label: 'GPU_IVF_FLAT',
+    value: GpuIndexTypeEnum.GPU_IVF_FLAT,
+  },
+  {
+    label: 'GPU_IVF_PQ',
+    value: GpuIndexTypeEnum.GPU_IVF_PQ,
+  },
+  {
+    label: 'GPU_CAGRA',
+    value: GpuIndexTypeEnum.GPU_CAGRA,
+  },
+];
+
+export const SEGMENT_SIZE_OPTIONS = [
+  {
+    label: '512 MB',
+    value: SegmentSizeEnum._512MB,
+  },
+  {
+    label: '1024 MB',
+    value: SegmentSizeEnum._1024MB,
+  },
+  {
+    label: '2048 MB',
+    value: SegmentSizeEnum._2048MB,
+  },
+];
+
+export const MODE_OPTIONS = [
+  {
+    label: 'Standalone',
+    value: ModeEnum.Standalone,
+  },
+  {
+    label: 'Distributed',
+    value: ModeEnum.Cluster,
+  },
+];
+
+/**
+ * Fixed cluster tiers, picked with `hostMemoryGB < memoryUpperBound`.
+ * Mirrors the kernel demo, which drops Index Node and adds Stream Node
+ * relative to the CPU sizing tool's FIXED_QUERY_NODE_CONFIG.
+ */
+export const GPU_FIXED_NODE_CONFIG = [
+  {
+    memoryUpperBound: 8,
+    queryNode: { cpu: 2, memory: 8, count: 1 },
+    proxy: { cpu: 1, memory: 4, count: 1 },
+    mixCoord: { cpu: 1, memory: 4, count: 1 },
+    dataNode: { cpu: 2, memory: 8, count: 1 },
+  },
+  {
+    memoryUpperBound: 16,
+    queryNode: { cpu: 4, memory: 16, count: 1 },
+    proxy: { cpu: 2, memory: 8, count: 1 },
+    mixCoord: { cpu: 2, memory: 8, count: 1 },
+    dataNode: { cpu: 4, memory: 16, count: 1 },
+  },
+  {
+    memoryUpperBound: 32,
+    queryNode: { cpu: 4, memory: 16, count: 2 },
+    proxy: { cpu: 2, memory: 8, count: 1 },
+    mixCoord: { cpu: 2, memory: 8, count: 1 },
+    dataNode: { cpu: 4, memory: 16, count: 2 },
+  },
+  {
+    memoryUpperBound: 48,
+    queryNode: { cpu: 4, memory: 16, count: 3 },
+    proxy: { cpu: 2, memory: 8, count: 1 },
+    mixCoord: { cpu: 2, memory: 8, count: 1 },
+    dataNode: { cpu: 4, memory: 16, count: 2 },
+  },
+  {
+    memoryUpperBound: 64,
+    queryNode: { cpu: 4, memory: 16, count: 4 },
+    proxy: { cpu: 2, memory: 8, count: 1 },
+    mixCoord: { cpu: 2, memory: 8, count: 1 },
+    dataNode: { cpu: 4, memory: 16, count: 2 },
+  },
+  {
+    memoryUpperBound: 80,
+    queryNode: { cpu: 4, memory: 16, count: 5 },
+    proxy: { cpu: 2, memory: 8, count: 1 },
+    mixCoord: { cpu: 2, memory: 8, count: 1 },
+    dataNode: { cpu: 4, memory: 16, count: 4 },
+  },
+  {
+    memoryUpperBound: 96,
+    queryNode: { cpu: 4, memory: 16, count: 6 },
+    proxy: { cpu: 2, memory: 8, count: 1 },
+    mixCoord: { cpu: 2, memory: 8, count: 1 },
+    dataNode: { cpu: 4, memory: 16, count: 4 },
+  },
+];
+
+/** Query node sizing above the fixed tiers; CPU is always `memory / 4`. */
+export const GPU_LARGE_QUERY_NODE_TIERS = [
+  { memoryUpperBound: 512, memory: 32 },
+  { memoryUpperBound: 2048, memory: 64 },
+  { memoryUpperBound: Infinity, memory: 128 },
+];
+
+export const GPU_LARGE_BASIC_NODE_CONFIG = {
+  proxy: { cpu: 8, memory: 32, count: 1 },
+  mixCoord: { cpu: 8, memory: 32, count: 1 },
+  dataNode: { cpu: 8, memory: 16, count: 8 },
+};
+
+/** One stream node unit covers 16 query node cores. */
+export const STREAM_NODE_CORES_PER_UNIT = 16;
+
+export const GPU_STREAM_NODE_TIERS = [
+  { unitsUpperBound: 1, cpu: 2, memory: 8, count: 1 },
+  { unitsUpperBound: 2, cpu: 4, memory: 16, count: 1 },
+  { unitsUpperBound: 4, cpu: 4, memory: 16, count: 2 },
+  { unitsUpperBound: 8, cpu: 8, memory: 32, count: 2 },
+];
+
+/** Applied above the last stream node tier; count is `ceil(units / 4)`. */
+export const GPU_STREAM_NODE_LARGE_CONFIG = { cpu: 8, memory: 32 };
+export const GPU_STREAM_NODE_LARGE_UNITS_PER_NODE = 4;
+
+/** Documentation link shown next to the index picker. */
+export const GPU_INDEX_DOC_LINK = '/docs/gpu_index.md';
+
+/** Short labels used in the GPU vs CPU comparison header. */
+export const GPU_INDEX_SHORT_LABELS: Record<GpuIndexTypeEnum, string> = {
+  [GpuIndexTypeEnum.GPU_BRUTE_FORCE]: 'BRUTE_FORCE',
+  [GpuIndexTypeEnum.GPU_IVF_FLAT]: 'IVF_FLAT',
+  [GpuIndexTypeEnum.GPU_IVF_PQ]: 'IVF_PQ',
+  [GpuIndexTypeEnum.GPU_CAGRA]: 'CAGRA',
+};
+
+/**
+ * Which `IGpuIndexMemory` components make up the per-segment breakdown list,
+ * in display order, for each index type.
+ */
+export const GPU_INDEX_BREAKDOWN_KEYS: Record<
+  GpuIndexTypeEnum,
+  (keyof IGpuIndexMemory)[]
+> = {
+  [GpuIndexTypeEnum.GPU_BRUTE_FORCE]: ['dataset', 'norms'],
+  [GpuIndexTypeEnum.GPU_IVF_FLAT]: [
+    'dataset',
+    'indices',
+    'centers',
+    'centerNorms',
+  ],
+  [GpuIndexTypeEnum.GPU_IVF_PQ]: ['codes', 'indices', 'centers', 'centerNorms'],
+  [GpuIndexTypeEnum.GPU_CAGRA]: ['dataset', 'graph'],
+};
+
+/** Enum names, shown verbatim in the validation banner. */
+export const GPU_VALIDATION_ERROR_CODES: Record<
+  GpuValidationErrorEnum,
+  string
+> = {
+  [GpuValidationErrorEnum.InvalidNumber]: 'InvalidNumber',
+  [GpuValidationErrorEnum.NlistOutOfRange]: 'NlistOutOfRange',
+  [GpuValidationErrorEnum.TrainFractionOutOfRange]: 'TrainFractionOutOfRange',
+  [GpuValidationErrorEnum.PqDimOutOfRange]: 'PqDimOutOfRange',
+  [GpuValidationErrorEnum.PqCodeNotByteAligned]: 'PqCodeNotByteAligned',
+  [GpuValidationErrorEnum.IntermediateDegreeTooSmall]:
+    'IntermediateDegreeTooSmall',
+};

--- a/src/i18n/en/sizingTool.json
+++ b/src/i18n/en/sizingTool.json
@@ -110,5 +110,69 @@
     "tip1": "How to run Milvus with Docker Compose?",
     "tip2": "How to run Milvus with Helm Chart?",
     "tip3": "How to run Milvus with Milvus Operator?"
+  },
+  "tabs": {
+    "cpu": "CPU Sizing",
+    "gpu": "GPU Sizing",
+    "new": "NEW",
+    "cpuHint": "The existing CPU estimation: loading memory, node configuration, dependencies and install commands.",
+    "gpuHint": "VRAM estimation for GPU_BRUTE_FORCE, GPU_IVF_FLAT, GPU_IVF_PQ and GPU_CAGRA, including the full derivation."
+  },
+  "gpu": {
+    "form": {
+      "million": "Million",
+      "averageLengthTip": "Host memory only — not counted into VRAM",
+      "indexDoc": "How to choose a GPU index?",
+      "trainFraction": "kmeans_trainset_fraction",
+      "pqDim": "pq_dim (m)",
+      "pqDimTip": "0 = cuVS Auto → {{value}}",
+      "pqBits": "nbits",
+      "graphDegree": "graph_degree",
+      "intermediateDegree": "intermediate_graph_degree",
+      "modeManualTip": "The GPU estimate does not switch mode automatically — pick the one you plan to deploy."
+    },
+    "result": {
+      "gpuMemory": "GPU Memory",
+      "gpuMemoryNote": "The ceiling is currently set by the {{stage}} stage ({{value}}), with a {{factor}}× headroom reserved on top.",
+      "coreCalculation": "Core Calculation",
+      "bytesPerRow": "Bytes per row",
+      "rowsPerSegment": "Rows per segment",
+      "segmentCount": "Segment count",
+      "effectiveParams": "Effective index params",
+      "noTunableParams": "no tunable parameters",
+      "perSegmentMemory": "Per-segment index memory",
+      "totalPerSegment": "Total per segment",
+      "lifecyclePeak": "Lifecycle peak",
+      "buildPeak": "Build peak",
+      "buildPeakDesc": "segment index + {{value}} temporary",
+      "resident": "Resident",
+      "residentDesc": "segment index × {{segments}} segments",
+      "limiting": "LIMITING",
+      "stageBuild": "build",
+      "stageResident": "resident",
+      "stageEqual": "build and resident",
+      "stageLoad": "load",
+      "componentsNote": "Node tiers and the Stream Node row are pending kernel confirmation; dependency services (etcd / MinIO / MQ) and GPU card mapping are not part of the GPU estimate yet.",
+      "compare": "GPU vs CPU",
+      "compareDesc": "Same data scale, compared against the CPU tool's FLAT baseline.",
+      "metric": "Metric",
+      "cpuBaseline": "CPU (FLAT)",
+      "compareRaw": "Raw data size",
+      "compareHost": "Host memory",
+      "compareVram": "GPU memory",
+      "compareStage": "Limiting stage",
+      "buildLimitingSingle": "Only a single segment, so the build stage sets the ceiling by definition — there is no multi-segment resident total to exceed it.",
+      "buildLimitingMulti": "The build-time temporary buffer ({{value}}) outweighs the resident index data, so the build stage sets the ceiling even across {{segments}} segments. IVF_PQ and CAGRA can do this at any segment count, because the training set and the intermediate graph are not compressed the way the final index is.",
+      "vram": "VRAM",
+      "vramWithValue": "VRAM: {{vram}}"
+    },
+    "errors": {
+      "invalidNumber": "Vector count must be greater than 0, dimension at least 2, and segment size positive.",
+      "nlistOutOfRange": "nlist must be between 1 and 65536.",
+      "trainFractionOutOfRange": "kmeans_trainset_fraction must be within (0, 1].",
+      "pqDimOutOfRange": "Resolved pq_dim must be within [1, d].",
+      "pqCodeNotByteAligned": "pq_dim × nbits must be a multiple of 8.",
+      "intermediateDegreeTooSmall": "intermediate_graph_degree must be greater than or equal to graph_degree."
+    }
   }
 }

--- a/src/pages/tools/sizing.tsx
+++ b/src/pages/tools/sizing.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import Layout from '@/components/layout/commonLayout';
 import classes from '@/styles/sizingTool.module.css';
@@ -30,11 +30,26 @@ import {
 import { useRouter } from 'next/router';
 import { SIZING_TOOL_VERSION_OPTIONS } from '@/consts/sizing';
 import { baseValues } from '@/parts/sizing/config';
-const { etcdBaseValue, minioBaseValue, pulsarBaseValue, kafkaBaseValue } = baseValues;
+import { SizingTabs, sizingTabId, sizingTabPanelId } from '@/components/sizing';
+import { GpuSizingTool } from '@/parts/sizingGpu';
+const { etcdBaseValue, minioBaseValue, pulsarBaseValue, kafkaBaseValue } =
+  baseValues;
 
 type Props = {
   locale: LanguageEnum;
   latestTag: string;
+};
+
+enum SizingTabEnum {
+  Cpu = 'cpu',
+  Gpu = 'gpu',
+}
+
+const TAB_ID_PREFIX = 'sizing';
+
+const readTabFromQuery = (value: string | string[] | undefined) => {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw === SizingTabEnum.Gpu ? SizingTabEnum.Gpu : SizingTabEnum.Cpu;
 };
 
 export default function SizingTool(props: Props) {
@@ -103,6 +118,36 @@ export default function SizingTool(props: Props) {
     currentVersion?.value || SIZING_TOOL_VERSION_OPTIONS[0].value
   );
 
+  // Defaults to CPU; `?tab=gpu` selects the GPU calculator so the view is
+  // linkable. Both panels stay mounted so each keeps its own form state.
+  const [tab, setTab] = useState<SizingTabEnum>(SizingTabEnum.Cpu);
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    setTab(readTabFromQuery(router.query.tab));
+  }, [router.isReady, router.query.tab]);
+
+  const handleTabChange = useCallback(
+    (value: SizingTabEnum) => {
+      setTab(value);
+
+      const query = { ...router.query };
+      if (value === SizingTabEnum.Gpu) {
+        query.tab = SizingTabEnum.Gpu;
+      } else {
+        delete query.tab;
+      }
+
+      router.replace({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+        scroll: false,
+      });
+    },
+    [router]
+  );
+
   const asyncCalculatedResult = (result: ICalculateResult) => {
     setCalculatedResult(result);
   };
@@ -162,18 +207,60 @@ export default function SizingTool(props: Props) {
             </div>
           </div>
 
-          <p className={classes.desc}>{t('content')}</p>
+          <p className={clsx(classes.desc, classes.descWithTabs)}>
+            {t('content')}
+          </p>
 
-          <div className={classes.contentContainer}>
-            <FormSection
-              className={classes.leftSection}
-              asyncCalculatedResult={asyncCalculatedResult}
-            />
-            <ResultSection
-              className={classes.rightSection}
-              calculatedResult={calculatedResult}
-              latestMilvusTag={latestTag}
-            />
+          <SizingTabs
+            className={classes.tabsRow}
+            idPrefix={TAB_ID_PREFIX}
+            value={tab}
+            onChange={handleTabChange}
+            hint={
+              tab === SizingTabEnum.Gpu ? t('tabs.gpuHint') : t('tabs.cpuHint')
+            }
+            options={[
+              { value: SizingTabEnum.Cpu, label: t('tabs.cpu') },
+              {
+                value: SizingTabEnum.Gpu,
+                label: t('tabs.gpu'),
+                badge: t('tabs.new'),
+              },
+            ]}
+          />
+
+          <div
+            role="tabpanel"
+            id={sizingTabPanelId(TAB_ID_PREFIX, SizingTabEnum.Cpu)}
+            aria-labelledby={sizingTabId(TAB_ID_PREFIX, SizingTabEnum.Cpu)}
+            hidden={tab !== SizingTabEnum.Cpu}
+            className={clsx({
+              [classes.hiddenPanel]: tab !== SizingTabEnum.Cpu,
+            })}
+          >
+            <div className={classes.contentContainer}>
+              <FormSection
+                className={classes.leftSection}
+                asyncCalculatedResult={asyncCalculatedResult}
+              />
+              <ResultSection
+                className={classes.rightSection}
+                calculatedResult={calculatedResult}
+                latestMilvusTag={latestTag}
+              />
+            </div>
+          </div>
+
+          <div
+            role="tabpanel"
+            id={sizingTabPanelId(TAB_ID_PREFIX, SizingTabEnum.Gpu)}
+            aria-labelledby={sizingTabId(TAB_ID_PREFIX, SizingTabEnum.Gpu)}
+            hidden={tab !== SizingTabEnum.Gpu}
+            className={clsx({
+              [classes.hiddenPanel]: tab !== SizingTabEnum.Gpu,
+            })}
+          >
+            <GpuSizingTool />
           </div>
 
           <ZillizAdv

--- a/src/parts/sizingGpu/config.ts
+++ b/src/parts/sizingGpu/config.ts
@@ -1,0 +1,155 @@
+import {
+  DIMENSION_RANGE_CONFIG,
+  GRAPH_DEGREE_RANGE_CONFIG,
+  INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG,
+  N_LIST_RANGE_CONFIG,
+  PQ_BITS_DEFAULT_VALUE,
+  PQ_DIM_RANGE_CONFIG,
+  TRAIN_FRACTION_RANGE_CONFIG,
+  VECTOR_RANGE_CONFIG,
+} from '@/consts/sizingGpu';
+import {
+  M_RANGE_CONFIG,
+  MAX_NODE_DEGREE_RANGE_CONFIG,
+  N_LIST_RANGE_CONFIG as CPU_N_LIST_RANGE_CONFIG,
+} from '@/consts/sizing';
+import {
+  GpuIndexTypeEnum,
+  GpuValidationErrorEnum,
+  IGpuCalculateResult,
+  IGpuSizingParams,
+  ModeEnum,
+  SegmentSizeEnum,
+} from '@/types/sizingGpu';
+import { IndexTypeEnum, RefineValueEnum } from '@/types/sizing';
+import {
+  gpuSizingCalculator,
+  validateGpuSizingParams,
+} from '@/utils/sizingToolGpu';
+import {
+  memoryAndDiskCalculator,
+  rawDataSizeCalculator,
+} from '@/utils/sizingTool';
+
+/** Every value the GPU form owns. Off-index parameters are kept, not reset. */
+export interface IGpuFormState {
+  num: number;
+  dimension: number;
+  withScalar: boolean;
+  scalarAvg: number;
+  indexType: GpuIndexTypeEnum;
+  nlist: number;
+  trainFraction: number;
+  pqDim: number;
+  pqBits: number;
+  graphDegree: number;
+  intermediateDegree: number;
+  segmentSize: SegmentSizeEnum;
+  mode: ModeEnum;
+}
+
+export const DEFAULT_GPU_FORM: IGpuFormState = {
+  num: VECTOR_RANGE_CONFIG.defaultValue,
+  dimension: DIMENSION_RANGE_CONFIG.defaultValue,
+  withScalar: false,
+  scalarAvg: 0,
+  indexType: GpuIndexTypeEnum.GPU_BRUTE_FORCE,
+  nlist: N_LIST_RANGE_CONFIG.defaultValue,
+  trainFraction: TRAIN_FRACTION_RANGE_CONFIG.defaultValue,
+  pqDim: PQ_DIM_RANGE_CONFIG.defaultValue,
+  pqBits: PQ_BITS_DEFAULT_VALUE,
+  graphDegree: GRAPH_DEGREE_RANGE_CONFIG.defaultValue,
+  intermediateDegree: INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG.defaultValue,
+  segmentSize: SegmentSizeEnum._1024MB,
+  mode: ModeEnum.Standalone,
+};
+
+/** The CPU tool's own numbers for the same data scale, for the comparison card. */
+export interface IGpuCpuBaseline {
+  rawDataSize: number;
+  memorySize: number;
+}
+
+/** One consistent set of results. Only replaced while the input is valid. */
+export interface IGpuSnapshot {
+  params: IGpuSizingParams;
+  result: IGpuCalculateResult;
+  cpuBaseline: IGpuCpuBaseline;
+}
+
+export interface IGpuPayload {
+  error: GpuValidationErrorEnum | null;
+  snapshot: IGpuSnapshot;
+}
+
+export const toGpuSizingParams = (form: IGpuFormState): IGpuSizingParams => ({
+  num: form.num,
+  d: form.dimension,
+  indexType: form.indexType,
+  withScalar: form.withScalar,
+  scalarAvg: form.scalarAvg,
+  segSize: Number(form.segmentSize),
+  mode: form.mode,
+  indexParams: {
+    nlist: form.nlist,
+    trainFraction: form.trainFraction,
+    pqDim: form.pqDim,
+    pqBits: form.pqBits,
+    graphDegree: form.graphDegree,
+    intermediateDegree: form.intermediateDegree,
+  },
+});
+
+/**
+ * The CPU tab's FLAT baseline at the GPU tab's data scale, produced by the CPU
+ * tool's own calculator rather than by a second copy of the formula.
+ */
+const cpuBaselineCalculator = (form: IGpuFormState): IGpuCpuBaseline => {
+  const shared = {
+    num: form.num,
+    d: form.dimension,
+    withScalar: form.withScalar,
+    scalarAvg: form.scalarAvg,
+  };
+  const rawDataSize = rawDataSizeCalculator(shared);
+
+  const { memory } = memoryAndDiskCalculator({
+    ...shared,
+    rawDataSize,
+    offLoading: false,
+    segSize: Number(form.segmentSize),
+    mode: form.mode,
+    refineType: RefineValueEnum.None,
+    indexTypeParams: {
+      indexType: IndexTypeEnum.FLAT,
+      widthRawData: false,
+      maxDegree: MAX_NODE_DEGREE_RANGE_CONFIG.defaultValue,
+      inlinePq: MAX_NODE_DEGREE_RANGE_CONFIG.defaultValue,
+      flatNList: CPU_N_LIST_RANGE_CONFIG.defaultValue,
+      sq8NList: CPU_N_LIST_RANGE_CONFIG.defaultValue,
+      rabitqNList: CPU_N_LIST_RANGE_CONFIG.defaultValue,
+      m: M_RANGE_CONFIG.defaultValue,
+    },
+  });
+
+  return { rawDataSize, memorySize: memory };
+};
+
+export const buildGpuPayload = (form: IGpuFormState): IGpuPayload => {
+  const params = toGpuSizingParams(form);
+
+  return {
+    error: validateGpuSizingParams(params),
+    snapshot: {
+      params,
+      result: gpuSizingCalculator(params),
+      cpuBaseline: cpuBaselineCalculator(form),
+    },
+  };
+};
+
+/**
+ * Derived from the defaults at module scope so the first paint already shows
+ * real numbers, on the server and on the client alike.
+ */
+export const INITIAL_GPU_SNAPSHOT = buildGpuPayload(DEFAULT_GPU_FORM).snapshot;

--- a/src/parts/sizingGpu/formSection.tsx
+++ b/src/parts/sizingGpu/formSection.tsx
@@ -1,0 +1,418 @@
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { Trans, useTranslation } from 'react-i18next';
+import { TooltipArrow } from '@radix-ui/react-tooltip';
+import { SizingInput, SizingRange, SizingSwitch } from '@/components/sizing';
+import {
+  Collapsible,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui';
+import { ExternalLinkIcon } from '@/components/icons';
+import commonClasses from '@/parts/sizingCommon/index.module.css';
+import classes from './index.module.css';
+import {
+  DEFAULT_GPU_FORM,
+  IGpuFormState,
+  IGpuPayload,
+  buildGpuPayload,
+} from './config';
+import {
+  DIMENSION_RANGE_CONFIG,
+  GPU_INDEX_DOC_LINK,
+  GPU_INDEX_TYPE_OPTIONS,
+  GRAPH_DEGREE_RANGE_CONFIG,
+  INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG,
+  MODE_OPTIONS,
+  N_LIST_RANGE_CONFIG,
+  PQ_BITS_OPTIONS,
+  PQ_DIM_RANGE_CONFIG,
+  SEGMENT_SIZE_OPTIONS,
+  TRAIN_FRACTION_RANGE_CONFIG,
+  VECTOR_RANGE_CONFIG,
+} from '@/consts/sizingGpu';
+import { GpuIndexTypeEnum, ModeEnum, SegmentSizeEnum } from '@/types/sizingGpu';
+import { calculatePqDim } from '@/utils/sizingToolGpu';
+
+/** Same ceiling the CPU tool puts on its scalar field. */
+const MAXIMUM_AVERAGE_LENGTH = 60000000;
+
+interface GpuFormSectionProps {
+  className?: string;
+  onCalculatedResult: (payload: IGpuPayload) => void;
+}
+
+/**
+ * Free-text numeric field, following the CPU tool's convention: the raw string
+ * lives in local state so intermediate input is not destroyed, the maximum is
+ * enforced while typing and the minimum on blur.
+ */
+const useNumericField = (
+  value: number,
+  range: { min: number; max: number },
+  onCommit: (value: number) => void
+) => {
+  const [text, setText] = useState<string>(`${value}`);
+
+  useEffect(() => {
+    // An empty draft is left alone: clearing a field commits the minimum, and
+    // refilling the box from that would fight the user mid-edit.
+    setText(current =>
+      current === '' || Number(current) === value ? current : `${value}`
+    );
+  }, [value]);
+
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    if (raw === '') {
+      setText('');
+      onCommit(range.min);
+      return;
+    }
+
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed)) {
+      return;
+    }
+    if (parsed > range.max) {
+      setText(`${range.max}`);
+      onCommit(range.max);
+      return;
+    }
+
+    setText(raw);
+    onCommit(parsed);
+  };
+
+  const onBlur = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (Number(event.target.value) < range.min) {
+      setText(`${range.min}`);
+      onCommit(range.min);
+    }
+  };
+
+  return { value: text, onChange, onBlur };
+};
+
+export default function GpuFormSection(props: GpuFormSectionProps) {
+  const { className, onCalculatedResult } = props;
+  const { t } = useTranslation('sizingTool');
+
+  const [form, setForm] = useState<IGpuFormState>(DEFAULT_GPU_FORM);
+
+  const updateForm = <K extends keyof IGpuFormState>(
+    key: K,
+    value: IGpuFormState[K]
+  ) => {
+    setForm(prev => ({ ...prev, [key]: value }));
+  };
+
+  useEffect(() => {
+    onCalculatedResult(buildGpuPayload(form));
+  }, [form, onCalculatedResult]);
+
+  const trainFractionField = useNumericField(
+    form.trainFraction,
+    TRAIN_FRACTION_RANGE_CONFIG,
+    value => updateForm('trainFraction', value)
+  );
+  const pqDimField = useNumericField(form.pqDim, PQ_DIM_RANGE_CONFIG, value =>
+    updateForm('pqDim', value)
+  );
+  const scalarField = useNumericField(
+    form.scalarAvg,
+    { min: 0, max: MAXIMUM_AVERAGE_LENGTH },
+    value => updateForm('scalarAvg', value)
+  );
+
+  const isIvf =
+    form.indexType === GpuIndexTypeEnum.GPU_IVF_FLAT ||
+    form.indexType === GpuIndexTypeEnum.GPU_IVF_PQ;
+  const isPq = form.indexType === GpuIndexTypeEnum.GPU_IVF_PQ;
+  const isCagra = form.indexType === GpuIndexTypeEnum.GPU_CAGRA;
+
+  const selectedSegmentSize = SEGMENT_SIZE_OPTIONS.find(
+    option => option.value === form.segmentSize
+  );
+
+  return (
+    <section className={clsx(className, commonClasses.formSection)}>
+      <div className={commonClasses.singlePart}>
+        <div className="mb-[24px]">
+          <SizingRange
+            rangeConfig={VECTOR_RANGE_CONFIG}
+            label={t('form.num')}
+            value={form.num}
+            onRangeChange={value => updateForm('num', value)}
+            unit={t('gpu.form.million')}
+          />
+        </div>
+        <div className="mb-[24px]">
+          <SizingRange
+            rangeConfig={DIMENSION_RANGE_CONFIG}
+            label={t('form.dim')}
+            value={form.dimension}
+            onRangeChange={value => updateForm('dimension', value)}
+            placeholder={`[${DIMENSION_RANGE_CONFIG.min}, ${DIMENSION_RANGE_CONFIG.max}]`}
+          />
+        </div>
+
+        <div className="mb-[24px]">
+          <h4 className="flex items-center justify-between mb-[8px]">
+            <span className="font-[600] text-[14px] leading-[22px] text-black1">
+              {t('form.indexType')}
+            </span>
+            <a
+              className="flex items-center gap-[4px] font-[400] text-[12px] leading-[16px] text-black1 hover:underline"
+              href={GPU_INDEX_DOC_LINK}
+              target="_blank"
+            >
+              {t('gpu.form.indexDoc')}
+              <ExternalLinkIcon />
+            </a>
+          </h4>
+
+          <Select
+            value={form.indexType}
+            onValueChange={value =>
+              updateForm('indexType', value as GpuIndexTypeEnum)
+            }
+          >
+            <SelectTrigger className={commonClasses.selectTrigger}>
+              {form.indexType}
+            </SelectTrigger>
+            <SelectContent>
+              {GPU_INDEX_TYPE_OPTIONS.map(option => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  className={commonClasses.selectItem}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {isIvf && (
+            <>
+              <div className="mt-[16px]">
+                <SizingRange
+                  rangeConfig={N_LIST_RANGE_CONFIG}
+                  label={t('form.nlist')}
+                  value={form.nlist}
+                  onRangeChange={value => updateForm('nlist', value)}
+                  placeholder={`[${N_LIST_RANGE_CONFIG.min}, ${N_LIST_RANGE_CONFIG.max}]`}
+                />
+              </div>
+              <div className="mt-[16px]">
+                <p className="text-[12px] font-[500] leading-[18px] mb-[8px]">
+                  {t('gpu.form.trainFraction')}
+                </p>
+                <SizingInput
+                  {...trainFractionField}
+                  placeholder={`[${TRAIN_FRACTION_RANGE_CONFIG.min}, ${TRAIN_FRACTION_RANGE_CONFIG.max}]`}
+                />
+              </div>
+            </>
+          )}
+
+          {isPq && (
+            <>
+              <div className="mt-[16px]">
+                <p className="text-[12px] font-[500] leading-[18px] mb-[8px]">
+                  {t('gpu.form.pqDim')}
+                </p>
+                <SizingInput
+                  {...pqDimField}
+                  placeholder={`[${PQ_DIM_RANGE_CONFIG.min}, ${PQ_DIM_RANGE_CONFIG.max}]`}
+                />
+                <p className={clsx('mt-[6px]', commonClasses.indexParamLabel)}>
+                  {t('gpu.form.pqDimTip', {
+                    value: calculatePqDim(form.dimension),
+                  })}
+                </p>
+              </div>
+              <div className="mt-[16px]">
+                <p className="text-[12px] font-[500] leading-[18px] mb-[8px]">
+                  {t('gpu.form.pqBits')}
+                </p>
+                <Select
+                  value={`${form.pqBits}`}
+                  onValueChange={value => updateForm('pqBits', Number(value))}
+                >
+                  <SelectTrigger className={commonClasses.selectTrigger}>
+                    {form.pqBits}
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PQ_BITS_OPTIONS.map(option => (
+                      <SelectItem
+                        key={option.value}
+                        value={`${option.value}`}
+                        className={commonClasses.selectItem}
+                      >
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </>
+          )}
+
+          {isCagra && (
+            <>
+              <div className="mt-[16px]">
+                <SizingRange
+                  rangeConfig={GRAPH_DEGREE_RANGE_CONFIG}
+                  label={t('gpu.form.graphDegree')}
+                  value={form.graphDegree}
+                  onRangeChange={value => updateForm('graphDegree', value)}
+                  placeholder={`[${GRAPH_DEGREE_RANGE_CONFIG.min}, ${GRAPH_DEGREE_RANGE_CONFIG.max}]`}
+                />
+              </div>
+              <div className="mt-[16px]">
+                <SizingRange
+                  rangeConfig={INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG}
+                  label={t('gpu.form.intermediateDegree')}
+                  value={form.intermediateDegree}
+                  onRangeChange={value =>
+                    updateForm('intermediateDegree', value)
+                  }
+                  placeholder={`[${INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG.min}, ${INTERMEDIATE_GRAPH_DEGREE_RANGE_CONFIG.max}]`}
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div>
+          <div className="flex items-center gap-[8px]">
+            <p className="text-[14px] leading-[22px] font-[600]">
+              {t('form.withScalar')}
+            </p>
+            <SizingSwitch
+              checked={form.withScalar}
+              onCheckedChange={value => updateForm('withScalar', value)}
+            />
+          </div>
+          <Collapsible
+            open={form.withScalar}
+            className={clsx(commonClasses.collapsible, {
+              [commonClasses.visibleCollapse]: form.withScalar,
+              [commonClasses.invisibleCollapse]: !form.withScalar,
+            })}
+          >
+            <SizingInput
+              label={t('form.averageLength')}
+              unit={t('setup.basic.byte')}
+              fullWidth
+              placeholder={`[ 0, 60,000,000 ]`}
+              classes={{ label: commonClasses.averageLabel }}
+              {...scalarField}
+            />
+            <p className={clsx('mt-[8px]', commonClasses.offLoadingDesc)}>
+              {t('gpu.form.averageLengthTip')}
+            </p>
+          </Collapsible>
+        </div>
+      </div>
+
+      <div className={clsx(commonClasses.singlePart, 'pb-[24px]')}>
+        <div className="mb-[24px]">
+          <h4>
+            <TooltipProvider>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger
+                  className={clsx(
+                    'text-[14px] font-[600] leading-[22px] mb-[8px]',
+                    commonClasses.tooltipTrigger
+                  )}
+                >
+                  {t('form.segmentSize')}
+                </TooltipTrigger>
+                <TooltipContent className="w-[280px]">
+                  <Trans
+                    t={t}
+                    i18nKey="form.segmentTooltip"
+                    components={[
+                      <a
+                        href="/docs/configure_datacoord.md#dataCoordsegmentmaxSize"
+                        key="segment-size"
+                        className={commonClasses.tooltipLink}
+                      ></a>,
+                    ]}
+                  />
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </h4>
+          <Select
+            value={form.segmentSize}
+            onValueChange={value =>
+              updateForm('segmentSize', value as SegmentSizeEnum)
+            }
+          >
+            <SelectTrigger className={commonClasses.selectTrigger}>
+              {selectedSegmentSize?.label}
+            </SelectTrigger>
+            <SelectContent>
+              {SEGMENT_SIZE_OPTIONS.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="mb-[24px]">
+          <h4 className="text-[14px] font-[600] leading-[22px] mb-[8px]">
+            {t('form.mode')}
+          </h4>
+          <div className={commonClasses.cardsWrapper}>
+            {MODE_OPTIONS.map(option => (
+              <div
+                key={option.value}
+                role="button"
+                className={clsx(commonClasses.card, commonClasses.modeCard, {
+                  [commonClasses.activeCard]: form.mode === option.value,
+                })}
+                onClick={() => updateForm('mode', option.value as ModeEnum)}
+              >
+                <h5 className="text-[14px] font-[600] leading-[22px]">
+                  {option.value === ModeEnum.Standalone
+                    ? t('form.standalone')
+                    : t('form.cluster')}
+                </h5>
+                <span className="text-[12px] font-[400] leading-[16px]">
+                  {option.value === ModeEnum.Standalone
+                    ? t('form.standaloneDesc')
+                    : t('form.clusterDesc')}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className={clsx('mt-[8px]', classes.modeHint)}>
+            {t('gpu.form.modeManualTip')}
+          </p>
+        </div>
+
+        <p className="mt-[36px] text-[12px] leading-[18px] text-black2">
+          <Trans
+            t={t}
+            i18nKey="tooltip"
+            components={[<span key="note" className="font-[600]"></span>]}
+          />
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/parts/sizingGpu/format.ts
+++ b/src/parts/sizingGpu/format.ts
@@ -1,0 +1,39 @@
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+const EMPTY = '—';
+
+/**
+ * Byte formatting for the GPU tab. Kept separate from `unitBYTE2Any` because
+ * the design calls for two decimals on every unit above bytes.
+ */
+export const formatGpuBytes = (value: number) => {
+  if (!Number.isFinite(value) || value < 0) {
+    return EMPTY;
+  }
+  if (value === 0) {
+    return '0 B';
+  }
+
+  let size = value;
+  let index = 0;
+  while (size >= 1024 && index < BYTE_UNITS.length - 1) {
+    size /= 1024;
+    index += 1;
+  }
+
+  const rendered = index === 0 ? `${Math.round(size)}` : size.toFixed(2);
+  return `${rendered} ${BYTE_UNITS[index]}`;
+};
+
+/**
+ * Thousands grouping without `toLocaleString`, so the server and the browser
+ * always produce the same string regardless of the available ICU data.
+ */
+export const formatGpuNumber = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return EMPTY;
+  }
+
+  const rounded = Math.round(value);
+  const sign = rounded < 0 ? '-' : '';
+  return sign + `${Math.abs(rounded)}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};

--- a/src/parts/sizingGpu/gpuSizingTool.tsx
+++ b/src/parts/sizingGpu/gpuSizingTool.tsx
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react';
+import pageClasses from '@/styles/sizingTool.module.css';
+import GpuFormSection from './formSection';
+import GpuResultSection from './resultSection';
+import { IGpuPayload, IGpuSnapshot, INITIAL_GPU_SNAPSHOT } from './config';
+import { GpuValidationErrorEnum } from '@/types/sizingGpu';
+
+export default function GpuSizingTool() {
+  const [snapshot, setSnapshot] = useState<IGpuSnapshot>(INITIAL_GPU_SNAPSHOT);
+  const [error, setError] = useState<GpuValidationErrorEnum | null>(null);
+
+  // An invalid combination keeps the last consistent set of numbers on screen
+  // instead of blanking the result column.
+  const handleCalculatedResult = useCallback((payload: IGpuPayload) => {
+    setError(payload.error);
+    if (!payload.error) {
+      setSnapshot(payload.snapshot);
+    }
+  }, []);
+
+  return (
+    <div className={pageClasses.contentContainer}>
+      <GpuFormSection
+        className={pageClasses.leftSection}
+        onCalculatedResult={handleCalculatedResult}
+      />
+      <GpuResultSection
+        className={pageClasses.rightSection}
+        snapshot={snapshot}
+        error={error}
+      />
+    </div>
+  );
+}

--- a/src/parts/sizingGpu/index.module.css
+++ b/src/parts/sizingGpu/index.module.css
@@ -1,0 +1,135 @@
+/**
+ * GPU tab additions only. Everything the CPU tab already has a look for —
+ * form sections, cards, collapsible headers, key/value labels — comes from
+ * `@/parts/sizingCommon/index.module.css`, so the two tabs stay identical.
+ */
+
+.modeHint {
+  @mixin paragraph6-regular;
+  color: var(--color-black2);
+}
+
+.errorWrapper {
+  padding: 16px 20px;
+  margin-bottom: 24px;
+  border-radius: 12px;
+  background-color: #fff4f3;
+  border: 1px solid #fda29b;
+
+  .errorCode {
+    @mixin paragraph6-bold;
+    color: #b42318;
+  }
+
+  .errorMessage {
+    @mixin paragraph6-regular;
+    margin-top: 4px;
+    color: #912018;
+  }
+}
+
+.stageNote {
+  @mixin paragraph6-regular;
+  color: var(--color-black2);
+}
+
+.warningCallout {
+  @mixin paragraph6-regular;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background-color: #fffaeb;
+  border: 1px solid #fedf89;
+  color: #93370d;
+}
+
+.footnote {
+  @mixin paragraph6-regular;
+  color: var(--color-black2);
+}
+
+.subTitle {
+  @mixin paragraph6-bold;
+}
+
+.detailRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 6px 0;
+}
+
+.detailValue {
+  @mixin paragraph6-bold;
+  color: var(--color-black1);
+  text-align: right;
+}
+
+.breakdownList {
+  list-style: none;
+  border-top: 1px solid var(--color-black4);
+
+  .detailRow {
+    border-bottom: 1px solid var(--color-black4);
+  }
+
+  .totalRow {
+    border-bottom: none;
+  }
+}
+
+.stageWrapper {
+  display: flex;
+  gap: 12px;
+
+  @media (--phone) {
+    flex-direction: column;
+  }
+
+  .stageCard {
+    flex: 1;
+    padding: 12px;
+    border-radius: 10px;
+    border: 1px solid var(--color-black3);
+    background: #fff;
+  }
+
+  .stageCardActive {
+    border-color: var(--color-blue1);
+  }
+
+  .stageCaption {
+    @mixin paragraph6-regular;
+    margin-top: 4px;
+    color: var(--color-black2);
+  }
+}
+
+.limitingTag {
+  @mixin paragraph6-bold;
+  padding: 0 6px;
+  border-radius: 4px;
+  background-color: #e0f2fc;
+  color: #008dc8;
+  white-space: nowrap;
+}
+
+.compareRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-black4);
+
+  span:not(:first-child) {
+    text-align: right;
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.compareHead {
+  padding-top: 0;
+}

--- a/src/parts/sizingGpu/index.ts
+++ b/src/parts/sizingGpu/index.ts
@@ -1,0 +1,5 @@
+export { default as GpuSizingTool } from './gpuSizingTool';
+export { default as GpuFormSection } from './formSection';
+export { default as GpuResultSection } from './resultSection';
+export * from './config';
+export * from './format';

--- a/src/parts/sizingGpu/resultSection.tsx
+++ b/src/parts/sizingGpu/resultSection.tsx
@@ -1,0 +1,646 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui';
+import { ExternalLinkIcon } from '@/components/icons';
+import { DataCard } from '@/parts/sizingCommon';
+import commonClasses from '@/parts/sizingCommon/index.module.css';
+import classes from './index.module.css';
+import { IGpuSnapshot } from './config';
+import { formatGpuBytes, formatGpuNumber } from './format';
+import {
+  GPU_INDEX_BREAKDOWN_KEYS,
+  GPU_INDEX_SHORT_LABELS,
+  GPU_MEMORY_SAFETY_FACTOR,
+  GPU_VALIDATION_ERROR_CODES,
+  PQ_DIM_AUTO,
+} from '@/consts/sizingGpu';
+import {
+  GpuIndexTypeEnum,
+  GpuLifecycleStageEnum,
+  GpuValidationErrorEnum,
+  IGpuIndexMemory,
+  ModeEnum,
+  NodesValueType,
+} from '@/types/sizingGpu';
+
+const CLOUD_CALCULATOR_LINK = 'https://zilliz.com/pricing#calculator';
+
+const STAGE_LABEL_KEYS: Record<GpuLifecycleStageEnum, string> = {
+  [GpuLifecycleStageEnum.Build]: 'gpu.result.stageBuild',
+  [GpuLifecycleStageEnum.Resident]: 'gpu.result.stageResident',
+  [GpuLifecycleStageEnum.Equal]: 'gpu.result.stageEqual',
+};
+
+/** Same chevron the CPU result section uses for its collapsible sections. */
+const ArrowDown = () => (
+  <svg
+    width="20"
+    height="21"
+    viewBox="0 0 20 21"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M5 8.5L10 13.5L15 8.5"
+      stroke="#00131A"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+interface INodeRow {
+  key: string;
+  name: string;
+  tip: string;
+  config: NodesValueType;
+}
+
+interface GpuResultSectionProps {
+  className?: string;
+  snapshot: IGpuSnapshot;
+  error: GpuValidationErrorEnum | null;
+}
+
+export default function GpuResultSection(props: GpuResultSectionProps) {
+  const { className, snapshot, error } = props;
+  const { t } = useTranslation('sizingTool');
+
+  const [isMilvusOpen, setIsMilvusOpen] = useState(true);
+  const [isCalculationOpen, setIsCalculationOpen] = useState(true);
+
+  const { params, result, cpuBaseline } = snapshot;
+  const {
+    rawDataSize,
+    memorySize,
+    segmentRowCount,
+    segmentCount,
+    effectiveIndexParams,
+    segmentIndexMemory,
+    segmentBuildTemporaryMemory,
+    buildMemorySize,
+    residentMemorySize,
+    lifecycleMaxMemorySize,
+    gpuMemorySize,
+    limitingStage,
+    clusterNodeConfig,
+    standaloneNodeConfig,
+    mode,
+  } = result;
+
+  const indexType = params.indexType;
+  const isStandalone = mode === ModeEnum.Standalone;
+  const stageLabel = t(STAGE_LABEL_KEYS[limitingStage]);
+
+  const buildIsLimiting =
+    limitingStage === GpuLifecycleStageEnum.Build ||
+    limitingStage === GpuLifecycleStageEnum.Equal;
+  const residentIsLimiting =
+    limitingStage === GpuLifecycleStageEnum.Resident ||
+    limitingStage === GpuLifecycleStageEnum.Equal;
+
+  const effectiveParamsLabel = useMemo(() => {
+    switch (indexType) {
+      case GpuIndexTypeEnum.GPU_IVF_FLAT:
+        return `nlist = min(${formatGpuNumber(
+          params.indexParams.nlist
+        )}, ${formatGpuNumber(segmentRowCount)}) = ${formatGpuNumber(
+          effectiveIndexParams.nlist
+        )}`;
+      case GpuIndexTypeEnum.GPU_IVF_PQ: {
+        const auto = params.indexParams.pqDim === PQ_DIM_AUTO;
+        return [
+          `nlist = ${formatGpuNumber(effectiveIndexParams.nlist)}`,
+          `pq_dim = ${formatGpuNumber(effectiveIndexParams.pqDim)}${
+            auto ? ' (cuVS Auto)' : ''
+          }`,
+          `nbits = ${effectiveIndexParams.pqBits}`,
+          `code = ${formatGpuNumber(
+            segmentIndexMemory.codeBytes || 0
+          )} B/vector`,
+        ].join(' · ');
+      }
+      case GpuIndexTypeEnum.GPU_CAGRA:
+        return [
+          `graph_degree = ${formatGpuNumber(effectiveIndexParams.graphDegree)}`,
+          `intermediate = ${formatGpuNumber(
+            effectiveIndexParams.intermediateDegree
+          )}`,
+        ].join(' · ');
+      default:
+        return t('gpu.result.noTunableParams');
+    }
+  }, [
+    indexType,
+    params.indexParams,
+    effectiveIndexParams,
+    segmentIndexMemory,
+    segmentRowCount,
+    t,
+  ]);
+
+  const breakdownRows = useMemo(
+    () =>
+      GPU_INDEX_BREAKDOWN_KEYS[indexType]
+        .map(key => ({
+          key,
+          value: segmentIndexMemory[key as keyof IGpuIndexMemory],
+        }))
+        .filter(row => typeof row.value === 'number') as {
+        key: string;
+        value: number;
+      }[],
+    [indexType, segmentIndexMemory]
+  );
+
+  const nodeRows = useMemo<INodeRow[]>(() => {
+    if (isStandalone) {
+      return [
+        {
+          key: 'standaloneNode',
+          name: t('setup.milvus.standaloneNode'),
+          tip: '',
+          config: standaloneNodeConfig,
+        },
+      ];
+    }
+
+    return [
+      {
+        key: 'proxy',
+        name: t('setup.milvus.proxy'),
+        tip: t('setup.milvus.proxyTip'),
+        config: clusterNodeConfig.proxy,
+      },
+      {
+        key: 'mixCoord',
+        name: t('setup.milvus.mixCoord'),
+        tip: t('setup.milvus.mixCoordTip'),
+        config: clusterNodeConfig.mixCoord,
+      },
+      {
+        key: 'dataNode',
+        name: t('setup.milvus.dataNode'),
+        tip: t('setup.milvus.dataNodeTip'),
+        config: clusterNodeConfig.dataNode,
+      },
+      {
+        key: 'streamNode',
+        name: t('setup.milvus.streamNode'),
+        tip: t('setup.milvus.streamNodeTip'),
+        config: clusterNodeConfig.streamNode,
+      },
+      {
+        key: 'queryNode',
+        name: t('setup.milvus.queryNode'),
+        tip: t('setup.milvus.queryNodeTip'),
+        config: clusterNodeConfig.queryNode,
+      },
+    ];
+  }, [isStandalone, standaloneNodeConfig, clusterNodeConfig, t]);
+
+  const totals = useMemo(
+    () =>
+      nodeRows.reduce(
+        (acc, row) => ({
+          cpu: acc.cpu + row.config.cpu * row.config.count,
+          memory: acc.memory + row.config.memory * row.config.count,
+          gpuMemory:
+            acc.gpuMemory + (row.config.gpuMemory || 0) * row.config.count,
+        }),
+        { cpu: 0, memory: 0, gpuMemory: 0 }
+      ),
+    [nodeRows]
+  );
+
+  const compareRows = useMemo(
+    () => [
+      {
+        key: 'raw',
+        metric: t('gpu.result.compareRaw'),
+        cpu: formatGpuBytes(cpuBaseline.rawDataSize),
+        gpu: formatGpuBytes(rawDataSize),
+      },
+      {
+        key: 'host',
+        metric: t('gpu.result.compareHost'),
+        cpu: formatGpuBytes(cpuBaseline.memorySize),
+        gpu: formatGpuBytes(memorySize),
+      },
+      {
+        key: 'vram',
+        metric: t('gpu.result.compareVram'),
+        cpu: '--',
+        gpu: formatGpuBytes(gpuMemorySize),
+      },
+      {
+        key: 'stage',
+        metric: t('gpu.result.compareStage'),
+        cpu: t('gpu.result.stageLoad'),
+        gpu: stageLabel,
+      },
+    ],
+    [cpuBaseline, rawDataSize, memorySize, gpuMemorySize, stageLabel, t]
+  );
+
+  return (
+    <section className={clsx(commonClasses.resultContainer, className)}>
+      {error && (
+        <div className={classes.errorWrapper} role="alert">
+          <p className={classes.errorCode}>
+            {GPU_VALIDATION_ERROR_CODES[error]}
+          </p>
+          <p className={classes.errorMessage}>{t(`gpu.errors.${error}`)}</p>
+        </div>
+      )}
+
+      <h2 className="flex justify-between items-center gap-[24px] mb-[12px]">
+        <span className="font-[600] text-[14px] leading-[22px]">
+          {t('overview.title')}
+        </span>
+        <a
+          className="flex items-center gap-[4px] font-[400] text-[12px] leading-[18px] text-black1 hover:underline"
+          href={CLOUD_CALCULATOR_LINK}
+          target="_blank"
+        >
+          {t('overview.explore')}
+          <ExternalLinkIcon />
+        </a>
+      </h2>
+
+      <div className="bg-gary2 pt-[20px] pb-[20px] rounded-[12px] mb-[24px]">
+        <div className="flex items-center justify-between pb-[10px] pl-[20px] pr-[20px] border-b border-solid border-black4">
+          <p className={commonClasses.commonKeyLabel}>
+            {t('overview.overview')}
+          </p>
+          <div className="flex items-center gap-[16px]">
+            <div className="flex items-center gap-[4px]">
+              <TooltipProvider>
+                <Tooltip delayDuration={0}>
+                  <TooltipTrigger
+                    className={clsx(
+                      commonClasses.commonKeyLabel,
+                      commonClasses.tooltipTrigger
+                    )}
+                  >
+                    {t('overview.raw')}
+                  </TooltipTrigger>
+                  <TooltipContent sideOffset={5} className="w-[280px]">
+                    {t('overview.rawTooltip')}
+                    <TooltipArrow />
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <span className={commonClasses.commonValueLabel}>
+                {formatGpuBytes(rawDataSize)}
+              </span>
+            </div>
+            <div className="flex items-center gap-[4px]">
+              <TooltipProvider>
+                <Tooltip delayDuration={0}>
+                  <TooltipTrigger
+                    className={clsx(
+                      commonClasses.commonKeyLabel,
+                      commonClasses.tooltipTrigger
+                    )}
+                  >
+                    {t('overview.memory')}
+                  </TooltipTrigger>
+                  <TooltipContent sideOffset={5} className="w-[280px]">
+                    {t('overview.memoryTooltip')}
+                    <TooltipArrow />
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <span className={commonClasses.commonValueLabel}>
+                {formatGpuBytes(memorySize)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-[20px] border-b border-solid border-black4 flex gap-[20px] justify-evenly">
+          <div className="flex-[1]">
+            <p className={clsx('mb-[6px]', commonClasses.font14Bold)}>
+              {t('gpu.result.gpuMemory')}
+            </p>
+            <p className={clsx('text-blue1', commonClasses.font16Bold)}>
+              {formatGpuBytes(gpuMemorySize)}
+            </p>
+          </div>
+          <div className="flex-[1]">
+            <p className={clsx('mb-[6px]', commonClasses.font14Bold)}>
+              {t('setup.basic.cpu')}
+            </p>
+            <p className={clsx('text-blue1', commonClasses.font16Bold)}>
+              {t('setup.basic.core', { cpu: formatGpuNumber(totals.cpu) })}
+            </p>
+          </div>
+          <div className="flex-[1]">
+            <p className={clsx('mb-[6px]', commonClasses.font14Bold)}>
+              {t('setup.basic.memory')}
+            </p>
+            <p className={clsx('text-blue1', commonClasses.font16Bold)}>
+              {t('setup.basic.gb', { memory: formatGpuNumber(totals.memory) })}
+            </p>
+          </div>
+        </div>
+
+        <div className="px-[20px] pt-[16px]">
+          <p className={classes.stageNote}>
+            {t('gpu.result.gpuMemoryNote', {
+              stage: stageLabel,
+              value: formatGpuBytes(lifecycleMaxMemorySize),
+              factor: GPU_MEMORY_SAFETY_FACTOR,
+            })}
+          </p>
+          {buildIsLimiting && (
+            <p className={clsx('mt-[12px]', classes.warningCallout)}>
+              {segmentCount === 1
+                ? t('gpu.result.buildLimitingSingle')
+                : t('gpu.result.buildLimitingMulti', {
+                    value: formatGpuBytes(segmentBuildTemporaryMemory),
+                    segments: formatGpuNumber(segmentCount),
+                  })}
+            </p>
+          )}
+        </div>
+
+        <div className="p-[20px] pb-[0px]">
+          <div className="pb-[20px] border-b border-solid border-black4">
+            <Collapsible open={isMilvusOpen} onOpenChange={setIsMilvusOpen}>
+              <CollapsibleTrigger className={commonClasses.commonCollapseTitle}>
+                <span
+                  className={clsx(commonClasses.collapseIcon, {
+                    [commonClasses.activeIcon]: isMilvusOpen,
+                  })}
+                >
+                  <ArrowDown />
+                </span>
+                <div className={commonClasses.collapseTitle}>
+                  <p className="font-[600] text-[12px] leading-[18px]">
+                    {t('setup.milvus.title')}
+                  </p>
+                  <div className="flex items-center gap-[12px]">
+                    <p className={commonClasses.commonKeyLabel}>
+                      {t('setup.basic.cpu')}:&nbsp;
+                      <span className="inline-block font-[600] text-[12px] leading-[18px] text-black1 text-left">
+                        {t('setup.basic.core', {
+                          cpu: formatGpuNumber(totals.cpu),
+                        })}
+                      </span>
+                    </p>
+                    <p className={commonClasses.commonKeyLabel}>
+                      {t('setup.basic.memory')}:&nbsp;
+                      <span className="inline-block font-[600] text-[12px] leading-[18px] text-black1 text-left">
+                        {t('setup.basic.gb', {
+                          memory: formatGpuNumber(totals.memory),
+                        })}
+                      </span>
+                    </p>
+                    <p className={commonClasses.commonKeyLabel}>
+                      {t('gpu.result.vram')}:&nbsp;
+                      <span className="inline-block font-[600] text-[12px] leading-[18px] text-blue1 text-left">
+                        {formatGpuBytes(totals.gpuMemory)}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className={commonClasses.milvusDataDetail}>
+                  {nodeRows.map(row => (
+                    <DataCard
+                      key={row.key}
+                      classname={commonClasses.detailCard}
+                      name={
+                        row.tip ? (
+                          <TooltipProvider>
+                            <Tooltip delayDuration={0}>
+                              <TooltipTrigger
+                                className={clsx(
+                                  commonClasses.commonKeyLabel,
+                                  commonClasses.tooltipTrigger
+                                )}
+                              >
+                                {row.name}
+                              </TooltipTrigger>
+                              <TooltipContent
+                                sideOffset={5}
+                                className="w-[280px]"
+                              >
+                                {row.tip}
+                                <TooltipArrow />
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : (
+                          row.name
+                        )
+                      }
+                      data={t('setup.basic.config', {
+                        cpu: row.config.cpu,
+                        memory: row.config.memory,
+                      })}
+                      desc={
+                        row.config.gpuMemory ? (
+                          <span className="text-blue1 font-[500]">
+                            {t('gpu.result.vramWithValue', {
+                              vram: formatGpuBytes(row.config.gpuMemory),
+                            })}
+                          </span>
+                        ) : undefined
+                      }
+                      count={row.config.count}
+                    />
+                  ))}
+                </div>
+                <p className={clsx('mt-[12px]', classes.footnote)}>
+                  {t('gpu.result.componentsNote')}
+                </p>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        </div>
+
+        <div className="p-[20px] pb-[0px]">
+          <Collapsible
+            open={isCalculationOpen}
+            onOpenChange={setIsCalculationOpen}
+          >
+            <CollapsibleTrigger className={commonClasses.commonCollapseTitle}>
+              <span
+                className={clsx(commonClasses.collapseIcon, {
+                  [commonClasses.activeIcon]: isCalculationOpen,
+                })}
+              >
+                <ArrowDown />
+              </span>
+              <div className={commonClasses.collapseTitle}>
+                <p className="font-[600] text-[12px] leading-[18px]">
+                  {t('gpu.result.coreCalculation')}
+                </p>
+                <p className={commonClasses.commonKeyLabel}>
+                  {t('gpu.result.segmentCount')}:&nbsp;
+                  <span className="inline-block font-[600] text-[12px] leading-[18px] text-black1 text-left">
+                    {formatGpuNumber(segmentCount)}
+                  </span>
+                </p>
+              </div>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className={commonClasses.milvusDataDetail}>
+                <DataCard
+                  classname={commonClasses.detailCard}
+                  name={t('gpu.result.bytesPerRow')}
+                  data={`${formatGpuNumber(params.d * 4)} B`}
+                />
+                <DataCard
+                  classname={commonClasses.detailCard}
+                  name={t('gpu.result.rowsPerSegment')}
+                  data={formatGpuNumber(segmentRowCount)}
+                />
+                <DataCard
+                  classname={commonClasses.detailCard}
+                  name={t('gpu.result.segmentCount')}
+                  data={formatGpuNumber(segmentCount)}
+                />
+              </div>
+
+              <div className={clsx('mt-[16px]', classes.detailRow)}>
+                <span className={commonClasses.commonKeyLabel}>
+                  {t('gpu.result.effectiveParams')}
+                </span>
+                <span className={classes.detailValue}>
+                  {effectiveParamsLabel}
+                </span>
+              </div>
+
+              <p className={clsx('mt-[16px] mb-[8px]', classes.subTitle)}>
+                {t('gpu.result.perSegmentMemory')}
+              </p>
+              <ul className={classes.breakdownList}>
+                {breakdownRows.map(row => (
+                  <li className={classes.detailRow} key={row.key}>
+                    <span className={commonClasses.commonKeyLabel}>
+                      {row.key}
+                    </span>
+                    <span className={classes.detailValue}>
+                      {formatGpuBytes(row.value)}
+                    </span>
+                  </li>
+                ))}
+                <li className={clsx(classes.detailRow, classes.totalRow)}>
+                  <span className="font-[600] text-[12px] leading-[18px]">
+                    {t('gpu.result.totalPerSegment')}
+                  </span>
+                  <span className={classes.detailValue}>
+                    {formatGpuBytes(segmentIndexMemory.total)}
+                  </span>
+                </li>
+              </ul>
+
+              <p className={clsx('mt-[16px] mb-[8px]', classes.subTitle)}>
+                {t('gpu.result.lifecyclePeak')}
+              </p>
+              <div className={classes.stageWrapper}>
+                <div
+                  className={clsx(classes.stageCard, {
+                    [classes.stageCardActive]: buildIsLimiting,
+                  })}
+                >
+                  <div className="flex items-center gap-[8px] mb-[4px]">
+                    <span className={commonClasses.commonKeyLabel}>
+                      {t('gpu.result.buildPeak')}
+                    </span>
+                    {buildIsLimiting && (
+                      <span className={classes.limitingTag}>
+                        {t('gpu.result.limiting')}
+                      </span>
+                    )}
+                  </div>
+                  <p className="font-[500] text-[12px] leading-[18px] text-black1">
+                    {formatGpuBytes(buildMemorySize)}
+                  </p>
+                  <p className={classes.stageCaption}>
+                    {t('gpu.result.buildPeakDesc', {
+                      value: formatGpuBytes(segmentBuildTemporaryMemory),
+                    })}
+                  </p>
+                </div>
+                <div
+                  className={clsx(classes.stageCard, {
+                    [classes.stageCardActive]: residentIsLimiting,
+                  })}
+                >
+                  <div className="flex items-center gap-[8px] mb-[4px]">
+                    <span className={commonClasses.commonKeyLabel}>
+                      {t('gpu.result.resident')}
+                    </span>
+                    {residentIsLimiting && (
+                      <span className={classes.limitingTag}>
+                        {t('gpu.result.limiting')}
+                      </span>
+                    )}
+                  </div>
+                  <p className="font-[500] text-[12px] leading-[18px] text-black1">
+                    {formatGpuBytes(residentMemorySize)}
+                  </p>
+                  <p className={classes.stageCaption}>
+                    {t('gpu.result.residentDesc', {
+                      segments: formatGpuNumber(segmentCount),
+                    })}
+                  </p>
+                </div>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      </div>
+
+      <h2 className="flex justify-between items-center gap-[24px] mb-[12px]">
+        <span className="font-[600] text-[14px] leading-[22px]">
+          {t('gpu.result.compare')}
+        </span>
+        <span className={commonClasses.commonKeyLabel}>
+          {t('gpu.result.compareDesc')}
+        </span>
+      </h2>
+      <div className="bg-gary2 rounded-[12px] p-[20px] mb-[24px]">
+        <div className={clsx(classes.compareRow, classes.compareHead)}>
+          <span className={commonClasses.commonKeyLabel}>
+            {t('gpu.result.metric')}
+          </span>
+          <span className={commonClasses.commonKeyLabel}>
+            {t('gpu.result.cpuBaseline')}
+          </span>
+          <span className={clsx(commonClasses.commonKeyLabel, 'text-blue1')}>
+            {`GPU (${GPU_INDEX_SHORT_LABELS[indexType]})`}
+          </span>
+        </div>
+        {compareRows.map(row => (
+          <div className={classes.compareRow} key={row.key}>
+            <span className={commonClasses.commonKeyLabel}>{row.metric}</span>
+            <span className="text-[12px] leading-[18px] font-[400] text-black1">
+              {row.cpu}
+            </span>
+            <span className="text-[12px] leading-[18px] font-[500] text-black1">
+              {row.gpu}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/styles/sizingTool.module.css
+++ b/src/styles/sizingTool.module.css
@@ -1,4 +1,3 @@
-
 .pageContainer {
   background-color: #fff;
 }
@@ -76,6 +75,20 @@
       color: var(--color-black1-5);
       text-decoration: underline;
     }
+  }
+
+  /* The tab switcher sits directly under the subtitle, so the airy 80px gap
+     below `.desc` moves to the bottom of the switcher block instead. */
+  .descWithTabs {
+    margin-bottom: 26px;
+  }
+
+  .tabsRow {
+    margin-bottom: 24px;
+  }
+
+  .hiddenPanel {
+    display: none;
   }
 
   .tipWrapper {

--- a/src/types/sizingGpu.ts
+++ b/src/types/sizingGpu.ts
@@ -1,0 +1,146 @@
+export type DataSizeUnit = 'B' | 'KB' | 'MB' | 'GB' | 'TB';
+
+export enum SegmentSizeEnum {
+  _512MB = '512',
+  _1024MB = '1024',
+  _2048MB = '2048',
+}
+
+export enum ModeEnum {
+  Standalone,
+  Cluster,
+}
+
+export enum GpuIndexTypeEnum {
+  GPU_BRUTE_FORCE = 'GPU_BRUTE_FORCE',
+  GPU_IVF_FLAT = 'GPU_IVF_FLAT',
+  GPU_IVF_PQ = 'GPU_IVF_PQ',
+  GPU_CAGRA = 'GPU_CAGRA',
+}
+
+/**
+ * Which lifecycle stage produced the GPU memory upper bound.
+ *
+ * Whether `Build` can win with two or more segments depends on the index:
+ * BRUTE_FORCE (no temporary at all) and IVF_FLAT (`trainRows × (4d+4)` is
+ * always below `n × (4d+8)`) guarantee that the resident total wins, but
+ * IVF_PQ and CAGRA do not — IVF_PQ trains on uncompressed float32 vectors
+ * while storing compressed codes, and CAGRA's intermediate graph can be far
+ * wider than `d + graph_degree`. Never assume a segment count from this value.
+ */
+export enum GpuLifecycleStageEnum {
+  Build = 'build',
+  Resident = 'resident',
+  Equal = 'equal',
+}
+
+export enum GpuValidationErrorEnum {
+  InvalidNumber = 'invalidNumber',
+  NlistOutOfRange = 'nlistOutOfRange',
+  TrainFractionOutOfRange = 'trainFractionOutOfRange',
+  PqDimOutOfRange = 'pqDimOutOfRange',
+  PqCodeNotByteAligned = 'pqCodeNotByteAligned',
+  IntermediateDegreeTooSmall = 'intermediateDegreeTooSmall',
+}
+
+/**
+ * Index parameters that take part in the GPU memory formulas. Parameters that
+ * are irrelevant to the selected index type are still carried (at their default
+ * values) so the shape stays stable across index switches.
+ */
+export interface IGpuIndexParams {
+  /** IVF cluster count. */
+  nlist: number;
+  /** IVF kmeans_trainset_fraction, (0, 1]. */
+  trainFraction: number;
+  /** PQ subspace count (`m`). `0` means "resolve with the cuVS auto rule". */
+  pqDim: number;
+  /** PQ code width in bits. */
+  pqBits: number;
+  /** CAGRA out-degree of the final graph. */
+  graphDegree: number;
+  /** CAGRA out-degree of the intermediate graph built during construction. */
+  intermediateDegree: number;
+}
+
+export interface IGpuSizingParams {
+  /** Vector count, in millions. */
+  num: number;
+  /** Vector dimension. */
+  d: number;
+  indexType: GpuIndexTypeEnum;
+  withScalar: boolean;
+  /** Average scalar bytes per row. */
+  scalarAvg: number;
+  /** Segment size in MB. */
+  segSize: number;
+  mode: ModeEnum;
+  indexParams: IGpuIndexParams;
+}
+
+/** Per-component breakdown of one segment's resident index data. */
+export interface IGpuIndexMemory {
+  total: number;
+  /** BRUTE_FORCE / CAGRA raw vectors, and the vector half of an IVF_FLAT list. */
+  dataset?: number;
+  /** BRUTE_FORCE precomputed norms. */
+  norms?: number;
+  /** IVF inverted lists (vectors or PQ codes, plus per-row ids). */
+  lists?: number;
+  /** The PQ code half of an IVF_PQ list. */
+  codes?: number;
+  /** The per-row id half of an IVF list. */
+  indices?: number;
+  /** IVF centroids. */
+  centers?: number;
+  /** IVF centroid norms. */
+  centerNorms?: number;
+  /** CAGRA adjacency list. */
+  graph?: number;
+  /** IVF_PQ bytes per encoded vector. */
+  codeBytes?: number;
+}
+
+export type NodesValueType = {
+  cpu: number;
+  /** Host memory in GB. */
+  memory: number;
+  count: number;
+  /** Per-node GPU memory in bytes. Absent for nodes that need no GPU. */
+  gpuMemory?: number;
+};
+
+const NodesType = {
+  queryNode: 'Query Node',
+  proxy: 'Proxy',
+  mixCoord: 'Mix Coord',
+  dataNode: 'Data Node',
+  streamNode: 'Stream Node',
+} as const;
+
+export type NodesKeyType = keyof typeof NodesType;
+
+export interface IGpuCalculateResult {
+  rawDataSize: number;
+  vectorRawDataSize: number;
+  scalarRawDataSize: number;
+  /** Host loading memory in bytes. */
+  memorySize: number;
+  segmentRowCount: number;
+  segmentCount: number;
+  /** Index parameters after auto-resolution and clamping. */
+  effectiveIndexParams: IGpuIndexParams;
+  segmentIndexMemory: IGpuIndexMemory;
+  segmentBuildTemporaryMemory: number;
+  /** Peak GPU memory while building one segment, in bytes. */
+  buildMemorySize: number;
+  /** GPU memory with every segment's index resident, in bytes. */
+  residentMemorySize: number;
+  lifecycleMaxMemorySize: number;
+  /** lifecycleMaxMemorySize with the safety factor applied, in bytes. */
+  gpuMemorySize: number;
+  limitingStage: GpuLifecycleStageEnum;
+  clusterNodeConfig: Record<NodesKeyType, NodesValueType>;
+  standaloneNodeConfig: NodesValueType;
+  mode: ModeEnum;
+}

--- a/src/utils/sizingToolGpu.ts
+++ b/src/utils/sizingToolGpu.ts
@@ -1,0 +1,425 @@
+import {
+  CPU_LOADING_SAFETY_FACTOR,
+  DEFAULT_GPU_INDEX_PARAMS,
+  FLOAT_BYTES,
+  GPU_FIXED_NODE_CONFIG,
+  GPU_INDEX_PARAM_KEYS,
+  GPU_LARGE_BASIC_NODE_CONFIG,
+  GPU_LARGE_QUERY_NODE_TIERS,
+  GPU_MEMORY_SAFETY_FACTOR,
+  GPU_STREAM_NODE_LARGE_CONFIG,
+  GPU_STREAM_NODE_LARGE_UNITS_PER_NODE,
+  GPU_STREAM_NODE_TIERS,
+  GRAPH_ID_BYTES,
+  IVF_ID_BYTES,
+  N_LIST_RANGE_CONFIG,
+  ONE_MILLION,
+  PQ_DIM_AUTO,
+  STREAM_NODE_CORES_PER_UNIT,
+} from '@/consts/sizingGpu';
+import {
+  GpuIndexTypeEnum,
+  GpuLifecycleStageEnum,
+  GpuValidationErrorEnum,
+  IGpuCalculateResult,
+  IGpuIndexMemory,
+  IGpuIndexParams,
+  IGpuSizingParams,
+  NodesKeyType,
+  NodesValueType,
+} from '@/types/sizingGpu';
+
+// Re-export common utilities
+export {
+  unitBYTE2Any,
+  unitAny2BYTE,
+  formatNumber,
+  formatOutOfCalData,
+} from './sizingToolCommon';
+
+import {
+  unitAny2BYTE,
+  unitBYTE2Any,
+  standaloneNodeConfigCalculator,
+} from './sizingToolCommon';
+
+const isIvfIndex = (indexType: GpuIndexTypeEnum) =>
+  indexType === GpuIndexTypeEnum.GPU_IVF_FLAT ||
+  indexType === GpuIndexTypeEnum.GPU_IVF_PQ;
+
+/**
+ * cuVS v26.02.00 `ivf_pq::index<IdxT>::calculate_pq_dim()`: halve dimensions of
+ * 128 and above, round down to a multiple of 32, and fall back to the largest
+ * power of two when the vector is too short for that.
+ */
+export const calculatePqDim = (d: number) => {
+  let candidate = Math.floor(d);
+  if (candidate >= 128) {
+    candidate = Math.floor(candidate / 2);
+  }
+
+  const multipleOf32 = Math.floor(candidate / 32) * 32;
+  if (multipleOf32 > 0) {
+    return multipleOf32;
+  }
+
+  let powerOfTwo = 1;
+  while (powerOfTwo * 2 <= candidate) {
+    powerOfTwo *= 2;
+  }
+  return powerOfTwo;
+};
+
+/**
+ * Normalise the index parameters for one index type: parameters that do not
+ * reach that index type's memory formulas fall back to their defaults, and an
+ * `m` / `pq_dim` of 0 is resolved through the cuVS auto rule.
+ */
+export const resolveIndexParams = (params: {
+  d: number;
+  indexType: GpuIndexTypeEnum;
+  indexParams: IGpuIndexParams;
+}): IGpuIndexParams => {
+  const { d, indexType, indexParams } = params;
+  const activeKeys = GPU_INDEX_PARAM_KEYS[indexType];
+
+  const resolved: IGpuIndexParams = { ...DEFAULT_GPU_INDEX_PARAMS };
+  activeKeys.forEach(key => {
+    resolved[key] = indexParams[key];
+  });
+
+  if (activeKeys.includes('pqDim') && resolved.pqDim === PQ_DIM_AUTO) {
+    resolved.pqDim = calculatePqDim(d);
+  }
+
+  return resolved;
+};
+
+/**
+ * Returns the first violated constraint, or `null` when the input is usable.
+ * Note that `nlist` is additionally clamped to the segment row count during the
+ * calculation itself, which is a silent adjustment rather than an error.
+ */
+export const validateGpuSizingParams = (
+  params: IGpuSizingParams
+): GpuValidationErrorEnum | null => {
+  const { num, d, segSize, withScalar, scalarAvg, indexType } = params;
+  const indexParams = resolveIndexParams(params);
+  const scalarBytes = withScalar ? scalarAvg : 0;
+
+  const values = [
+    num,
+    d,
+    segSize,
+    scalarBytes,
+    indexParams.nlist,
+    indexParams.trainFraction,
+    indexParams.pqDim,
+    indexParams.pqBits,
+    indexParams.graphDegree,
+    indexParams.intermediateDegree,
+  ];
+
+  if (
+    values.some(value => !Number.isFinite(value) || value < 0) ||
+    num <= 0 ||
+    d < 2 ||
+    segSize <= 0
+  ) {
+    return GpuValidationErrorEnum.InvalidNumber;
+  }
+
+  if (
+    isIvfIndex(indexType) &&
+    (indexParams.nlist < N_LIST_RANGE_CONFIG.min ||
+      indexParams.nlist > N_LIST_RANGE_CONFIG.max)
+  ) {
+    return GpuValidationErrorEnum.NlistOutOfRange;
+  }
+
+  if (
+    isIvfIndex(indexType) &&
+    (indexParams.trainFraction <= 0 || indexParams.trainFraction > 1)
+  ) {
+    return GpuValidationErrorEnum.TrainFractionOutOfRange;
+  }
+
+  if (indexType === GpuIndexTypeEnum.GPU_IVF_PQ) {
+    if (indexParams.pqDim < 1 || indexParams.pqDim > d) {
+      return GpuValidationErrorEnum.PqDimOutOfRange;
+    }
+    if ((indexParams.pqDim * indexParams.pqBits) % 8 !== 0) {
+      return GpuValidationErrorEnum.PqCodeNotByteAligned;
+    }
+  }
+
+  if (
+    indexType === GpuIndexTypeEnum.GPU_CAGRA &&
+    indexParams.intermediateDegree < indexParams.graphDegree
+  ) {
+    return GpuValidationErrorEnum.IntermediateDegreeTooSmall;
+  }
+
+  return null;
+};
+
+/**
+ * Resident index data of a single segment, in bytes. This part occupies GPU
+ * memory during build, load and search alike.
+ */
+export const gpuIndexMemoryCalculator = (params: {
+  n: number;
+  d: number;
+  indexType: GpuIndexTypeEnum;
+  indexParams: IGpuIndexParams;
+}): IGpuIndexMemory => {
+  const { n, d, indexType, indexParams } = params;
+  const { nlist, pqDim, pqBits, graphDegree } = indexParams;
+
+  switch (indexType) {
+    case GpuIndexTypeEnum.GPU_BRUTE_FORCE: {
+      const dataset = n * d * FLOAT_BYTES;
+      const norms = n * FLOAT_BYTES;
+      return { total: dataset + norms, dataset, norms };
+    }
+    case GpuIndexTypeEnum.GPU_IVF_FLAT: {
+      const lists = n * (d * FLOAT_BYTES + IVF_ID_BYTES);
+      const centers = nlist * d * FLOAT_BYTES;
+      const centerNorms = nlist * FLOAT_BYTES;
+      return {
+        total: lists + centers + centerNorms,
+        lists,
+        // The two halves of `lists`, reported for display only.
+        dataset: n * d * FLOAT_BYTES,
+        indices: n * IVF_ID_BYTES,
+        centers,
+        centerNorms,
+      };
+    }
+    case GpuIndexTypeEnum.GPU_IVF_PQ: {
+      const codeBytes = Math.ceil((pqDim * pqBits) / 8);
+      const lists = n * (codeBytes + IVF_ID_BYTES);
+      const centers = nlist * d * FLOAT_BYTES;
+      const centerNorms = nlist * FLOAT_BYTES;
+      return {
+        total: lists + centers + centerNorms,
+        lists,
+        // The two halves of `lists`, reported for display only.
+        codes: n * codeBytes,
+        indices: n * IVF_ID_BYTES,
+        centers,
+        centerNorms,
+        codeBytes,
+      };
+    }
+    case GpuIndexTypeEnum.GPU_CAGRA:
+    default: {
+      const dataset = n * d * FLOAT_BYTES;
+      const graph = n * graphDegree * GRAPH_ID_BYTES;
+      return { total: dataset + graph, dataset, graph };
+    }
+  }
+};
+
+/**
+ * Extra GPU memory held only while a single segment's index is being built,
+ * on top of the resident index data.
+ */
+export const gpuBuildTemporaryMemoryCalculator = (params: {
+  n: number;
+  d: number;
+  indexType: GpuIndexTypeEnum;
+  indexParams: IGpuIndexParams;
+}) => {
+  const { n, d, indexType, indexParams } = params;
+
+  if (isIvfIndex(indexType)) {
+    const trainRows = Math.floor(n * indexParams.trainFraction);
+    return trainRows * d * FLOAT_BYTES + trainRows * FLOAT_BYTES;
+  }
+
+  if (indexType === GpuIndexTypeEnum.GPU_CAGRA) {
+    return n * indexParams.intermediateDegree * GRAPH_ID_BYTES;
+  }
+
+  return 0;
+};
+
+/** Host loading memory, in bytes. Same formula as the CPU tool's FLAT branch. */
+export const hostLoadingMemoryCalculator = (params: {
+  num: number;
+  d: number;
+  withScalar: boolean;
+  scalarAvg: number;
+  segSize: number;
+}) => {
+  const { num, d, withScalar, scalarAvg, segSize } = params;
+  const segmentSizeByte = unitAny2BYTE(segSize, 'MB');
+  const totalN = num * ONE_MILLION;
+
+  const vectorRawDataSize = totalN * d * FLOAT_BYTES;
+  const scalarRawDataSize = withScalar ? totalN * scalarAvg : 0;
+
+  return (
+    (vectorRawDataSize + 2 * segmentSizeByte) * CPU_LOADING_SAFETY_FACTOR +
+    scalarRawDataSize
+  );
+};
+
+/** Stream node sizing, driven by the total number of query node cores. */
+export const streamNodeConfigCalculator = (params: {
+  queryNodeCores: number;
+}): NodesValueType => {
+  const units = Math.ceil(params.queryNodeCores / STREAM_NODE_CORES_PER_UNIT);
+  const tier = GPU_STREAM_NODE_TIERS.find(
+    item => units <= item.unitsUpperBound
+  );
+
+  if (tier) {
+    return { cpu: tier.cpu, memory: tier.memory, count: tier.count };
+  }
+
+  return {
+    ...GPU_STREAM_NODE_LARGE_CONFIG,
+    count: Math.ceil(units / GPU_STREAM_NODE_LARGE_UNITS_PER_NODE),
+  };
+};
+
+/** Cluster node sizing, driven by the host loading memory. */
+export const clusterNodeConfigCalculator = (params: {
+  memory: number;
+}): Record<NodesKeyType, NodesValueType> => {
+  const { size: memoryGB } = unitBYTE2Any(params.memory, 'GB');
+
+  const fixed = GPU_FIXED_NODE_CONFIG.find(
+    item => memoryGB < item.memoryUpperBound
+  );
+
+  if (fixed) {
+    const queryNode = { ...fixed.queryNode };
+    return {
+      queryNode,
+      proxy: { ...fixed.proxy },
+      mixCoord: { ...fixed.mixCoord },
+      dataNode: { ...fixed.dataNode },
+      streamNode: streamNodeConfigCalculator({
+        queryNodeCores: queryNode.cpu * queryNode.count,
+      }),
+    };
+  }
+
+  const tier =
+    GPU_LARGE_QUERY_NODE_TIERS.find(item => memoryGB < item.memoryUpperBound) ||
+    GPU_LARGE_QUERY_NODE_TIERS[GPU_LARGE_QUERY_NODE_TIERS.length - 1];
+  const queryNode = {
+    cpu: tier.memory / 4,
+    memory: tier.memory,
+    count: Math.ceil(memoryGB / tier.memory),
+  };
+
+  return {
+    queryNode,
+    proxy: { ...GPU_LARGE_BASIC_NODE_CONFIG.proxy },
+    mixCoord: { ...GPU_LARGE_BASIC_NODE_CONFIG.mixCoord },
+    dataNode: { ...GPU_LARGE_BASIC_NODE_CONFIG.dataNode },
+    streamNode: streamNodeConfigCalculator({
+      queryNodeCores: queryNode.cpu * queryNode.count,
+    }),
+  };
+};
+
+/**
+ * Full GPU sizing estimate. Call `validateGpuSizingParams` first: this function
+ * assumes the input already passed validation.
+ */
+export const gpuSizingCalculator = (
+  params: IGpuSizingParams
+): IGpuCalculateResult => {
+  const { num, d, indexType, withScalar, scalarAvg, segSize, mode } = params;
+
+  const totalN = num * ONE_MILLION;
+  const segmentSizeByte = unitAny2BYTE(segSize, 'MB');
+  const rowBytes = d * FLOAT_BYTES;
+  const segmentRowCount = Math.max(
+    1,
+    Math.min(totalN, Math.floor(segmentSizeByte / rowBytes))
+  );
+  const segmentCount = Math.ceil(totalN / segmentRowCount);
+
+  // nlist can never exceed the number of rows it has to cluster.
+  const resolvedParams = resolveIndexParams(params);
+  const effectiveIndexParams: IGpuIndexParams = {
+    ...resolvedParams,
+    nlist: Math.min(resolvedParams.nlist, segmentRowCount),
+  };
+
+  const vectorRawDataSize = totalN * rowBytes;
+  const scalarRawDataSize = withScalar ? totalN * scalarAvg : 0;
+  const memorySize = hostLoadingMemoryCalculator({
+    num,
+    d,
+    withScalar,
+    scalarAvg,
+    segSize,
+  });
+
+  const segmentIndexMemory = gpuIndexMemoryCalculator({
+    n: segmentRowCount,
+    d,
+    indexType,
+    indexParams: effectiveIndexParams,
+  });
+  const segmentBuildTemporaryMemory = gpuBuildTemporaryMemoryCalculator({
+    n: segmentRowCount,
+    d,
+    indexType,
+    indexParams: effectiveIndexParams,
+  });
+
+  const buildMemorySize =
+    segmentIndexMemory.total + segmentBuildTemporaryMemory;
+  const residentMemorySize = segmentIndexMemory.total * segmentCount;
+  const lifecycleMaxMemorySize = Math.max(buildMemorySize, residentMemorySize);
+  const gpuMemorySize = lifecycleMaxMemorySize * GPU_MEMORY_SAFETY_FACTOR;
+
+  let limitingStage = GpuLifecycleStageEnum.Equal;
+  if (buildMemorySize > residentMemorySize) {
+    limitingStage = GpuLifecycleStageEnum.Build;
+  } else if (residentMemorySize > buildMemorySize) {
+    limitingStage = GpuLifecycleStageEnum.Resident;
+  }
+
+  const standaloneNodeConfig: NodesValueType = {
+    ...standaloneNodeConfigCalculator({ memory: memorySize }),
+    gpuMemory: gpuMemorySize,
+  };
+
+  // Query nodes hold every segment's index; the data node only needs enough
+  // memory to build one segment at a time.
+  const clusterNodeConfig = clusterNodeConfigCalculator({ memory: memorySize });
+  clusterNodeConfig.queryNode.gpuMemory =
+    (residentMemorySize * GPU_MEMORY_SAFETY_FACTOR) /
+    clusterNodeConfig.queryNode.count;
+  clusterNodeConfig.dataNode.gpuMemory =
+    buildMemorySize * GPU_MEMORY_SAFETY_FACTOR;
+
+  return {
+    rawDataSize: vectorRawDataSize + scalarRawDataSize,
+    vectorRawDataSize,
+    scalarRawDataSize,
+    memorySize,
+    segmentRowCount,
+    segmentCount,
+    effectiveIndexParams,
+    segmentIndexMemory,
+    segmentBuildTemporaryMemory,
+    buildMemorySize,
+    residentMemorySize,
+    lifecycleMaxMemorySize,
+    gpuMemorySize,
+    limitingStage,
+    clusterNodeConfig,
+    standaloneNodeConfig,
+    mode,
+  };
+};


### PR DESCRIPTION
## What

Adds GPU (VRAM) estimation to `/tools/sizing` for `GPU_BRUTE_FORCE`, `GPU_IVF_FLAT`, `GPU_IVF_PQ` and `GPU_CAGRA`.

The CPU and GPU calculators are **tabs on the same page**, not separate routes. The tab is reflected in the URL (`?tab=gpu`) so a GPU estimate is linkable, and both panels stay mounted so each tab keeps its own form state.

The existing CPU tool is unchanged — it is only wrapped in a tab panel. `/tools/sizing-v250`, `/tools/sizing-enterprise` and `/tools/sizing-v250-enterprise` are untouched.

## Where the numbers come from

The algorithm is derived strictly from the kernel team's second sizing demo, with no extrapolation. It is written up in [`gpu-sizing-spec.md`](gpu-sizing-spec.md) (included in this PR) and implemented as pure functions in `src/utils/sizingToolGpu.ts`.

| Stage | Formula |
| --- | --- |
| Per-segment index | BF `N·D·4 + N·4` · IVF_FLAT `N·(D·4+8) + nlist·D·4 + nlist·4` · IVF_PQ `N·(ceil(pq_dim·nbits÷8)+8) + nlist·D·4 + nlist·4` · CAGRA `N·D·4 + N·graph_degree·4` |
| Build temporary | IVF `N_train·(D·4+4)` · CAGRA `N·intermediate_graph_degree·4` · BF `0` |
| Ceiling | `max(build, resident) × 1.5` |

## Verification

A differential harness drives the reference demo in headless Chromium and diffs its rendered output field-by-field against this implementation:

```
cases: 803   mismatches: 0
index types:  bf 145 / ivfFlat 188 / ivfPq 201 / cagra 191
stages:       resident 496 / build 187 / equal 42
segments:     multi 546 / single 179
validation:   all 6 error codes exercised, no divergence
node tiers:   all 5 query-node and all 5 stream-node tier shapes hit
```

Also checked in the browser: no console errors or hydration warnings, tab state survives switching, URL sync works both ways, validation banner keeps the last valid numbers on screen instead of blanking, and no horizontal overflow at 430px. `tsc --noEmit` and Prettier are clean.

## UI

The GPU tab reuses the CPU tool's own controls (`SizingRange`, `SizingInput`, `SizingSwitch`, Radix `Select`) and its result grammar (`@/parts/sizingCommon`), so the two tabs read as one product. Only GPU-specific pieces — the validation banner, the per-segment breakdown, the lifecycle-peak cards and the comparison table — carry new styles.

New copy is added to `src/i18n/en/sizingTool.json` only; other locales fall back to English through the existing `fallbackLng` mechanism. The change to that file is purely additive — no existing key was removed or altered.

## Open questions for the kernel team

These are surfaced in the UI rather than hidden, and tracked in section five of the spec:

- `GPU_MEMORY_SAFETY_FACTOR = 1.5` has no source, and does not address RMM pool fragmentation.
- The Workspace Pool's 1 GB floor is not counted; search workspace `T(n_queries)` is treated as 0 (no topk / nprobe / concurrency inputs).
- Whether the peak is `max(build, resident)` or `resident + buildTemp × concurrency`, especially in Standalone.
- Node tiers and the Stream Node row have no source and diverge from the CPU tool's table (which keeps Index Node and has no Stream Node).
- Dependency services (etcd / MinIO / MQ) and install-command generation are not part of the GPU estimate yet — the generated YAML would need GPU resource limits.
- No GPU card capacity table exists, so the tool deliberately reports **no** card count.

One correction worth calling out: an earlier draft of the spec claimed `limitingStage = build` could only occur with a single segment. That holds for BRUTE_FORCE and IVF_FLAT but **not** for IVF_PQ or CAGRA — IVF_PQ trains on uncompressed float32 vectors while storing compressed codes, so its temporary buffer can dwarf the index data at any segment count. The spec, the enum doc comment and the UI hint have all been corrected, and the test data confirms it (`ivfPq | build | multi` occurs 49 times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)