### PR TITLE
refactor(sizing): drop the Effective index params row from the GPU tab

### DIFF
--- a/gpu-sizing-spec.md
+++ b/gpu-sizing-spec.md
@@ -75,19 +75,19 @@
 
 建议做成可折叠、默认展开——GPU 估算比 CPU 更需要向用户交代推导过程。
 
-| 展示项              | 字段                                       | 示例渲染                                                                                                  |
-| ------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| 单行字节            | 由 `d` 推                                  | `768 × 4 = 3,072 Bytes`                                                                                   |
-| 单段行数            | `segmentRowCount`                          | `1024 MiB ÷ 3,072 = 349,525 vectors`                                                                      |
-| 段数                | `segmentCount`                             | `ceil(1,000,000 ÷ 349,525) = 3`                                                                           |
-| 生效索引参数        | `effectiveIndexParams`                     | 展示**钳制 / 自动解析后**的值：`nlist` 被 `min(nlist, 段行数)` 压过、`pqDim = 0` 被 cuVS 规则解析成实际值 |
-| PQ 单向量编码字节   | `segmentIndexMemory.codeBytes`             | 仅 IVF_PQ：`ceil(m × pq_bits ÷ 8)`                                                                        |
-| 单段索引公式 + 分项 | `segmentIndexMemory`                       | 分项 `dataset / norms / lists / centers / centerNorms / graph`，随索引类型不同                            |
-| 单段索引数据量      | `segmentIndexMemory.total`                 |                                                                                                           |
-| 构建临时显存        | `segmentBuildTemporaryMemory`              | IVF 是训练集，CAGRA 是中间图，BRUTE_FORCE 为 0                                                            |
-| **Build 峰值**      | `buildMemorySize`                          | 单段索引 + 临时                                                                                           |
-| **Resident 常驻**   | `residentMemorySize`                       | 单段索引 × 段数                                                                                           |
-| 生命周期最大值      | `lifecycleMaxMemorySize` / `limitingStage` | 两者取大                                                                                                  |
+| 展示项              | 字段                                       | 示例渲染                                                                                                                           |
+| ------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 单行字节            | 由 `d` 推                                  | `768 × 4 = 3,072 Bytes`                                                                                                            |
+| 单段行数            | `segmentRowCount`                          | `1024 MiB ÷ 3,072 = 349,525 vectors`                                                                                               |
+| 段数                | `segmentCount`                             | `ceil(1,000,000 ÷ 349,525) = 3`                                                                                                    |
+| ~~生效索引参数~~    | `effectiveIndexParams`                     | **已决定不展示**。钳制与自动解析照常发生（`nlist` 被 `min(nlist, 段行数)` 压过、`pqDim = 0` 走 cuVS 规则），只是不在 UI 上单列一行 |
+| PQ 单向量编码字节   | `segmentIndexMemory.codeBytes`             | 仅 IVF_PQ：`ceil(m × pq_bits ÷ 8)`                                                                                                 |
+| 单段索引公式 + 分项 | `segmentIndexMemory`                       | 分项 `dataset / norms / lists / centers / centerNorms / graph`，随索引类型不同                                                     |
+| 单段索引数据量      | `segmentIndexMemory.total`                 |                                                                                                                                    |
+| 构建临时显存        | `segmentBuildTemporaryMemory`              | IVF 是训练集，CAGRA 是中间图，BRUTE_FORCE 为 0                                                                                     |
+| **Build 峰值**      | `buildMemorySize`                          | 单段索引 + 临时                                                                                                                    |
+| **Resident 常驻**   | `residentMemorySize`                       | 单段索引 × 段数                                                                                                                    |
+| 生命周期最大值      | `lifecycleMaxMemorySize` / `limitingStage` | 两者取大                                                                                                                           |
 
 单段索引数据公式（`gpuIndexMemoryCalculator`）：
 

--- a/src/i18n/en/sizingTool.json
+++ b/src/i18n/en/sizingTool.json
@@ -138,8 +138,6 @@
       "bytesPerRow": "Bytes per row",
       "rowsPerSegment": "Rows per segment",
       "segmentCount": "Segment count",
-      "effectiveParams": "Effective index params",
-      "noTunableParams": "no tunable parameters",
       "perSegmentMemory": "Per-segment index memory",
       "totalPerSegment": "Total per segment",
       "lifecyclePeak": "Lifecycle peak",

--- a/src/parts/sizingGpu/resultSection.tsx
+++ b/src/parts/sizingGpu/resultSection.tsx
@@ -22,10 +22,8 @@ import {
   GPU_INDEX_SHORT_LABELS,
   GPU_MEMORY_SAFETY_FACTOR,
   GPU_VALIDATION_ERROR_CODES,
-  PQ_DIM_AUTO,
 } from '@/consts/sizingGpu';
 import {
-  GpuIndexTypeEnum,
   GpuLifecycleStageEnum,
   GpuValidationErrorEnum,
   IGpuIndexMemory,
@@ -86,7 +84,6 @@ export default function GpuResultSection(props: GpuResultSectionProps) {
     memorySize,
     segmentRowCount,
     segmentCount,
-    effectiveIndexParams,
     segmentIndexMemory,
     segmentBuildTemporaryMemory,
     buildMemorySize,
@@ -109,46 +106,6 @@ export default function GpuResultSection(props: GpuResultSectionProps) {
   const residentIsLimiting =
     limitingStage === GpuLifecycleStageEnum.Resident ||
     limitingStage === GpuLifecycleStageEnum.Equal;
-
-  const effectiveParamsLabel = useMemo(() => {
-    switch (indexType) {
-      case GpuIndexTypeEnum.GPU_IVF_FLAT:
-        return `nlist = min(${formatGpuNumber(
-          params.indexParams.nlist
-        )}, ${formatGpuNumber(segmentRowCount)}) = ${formatGpuNumber(
-          effectiveIndexParams.nlist
-        )}`;
-      case GpuIndexTypeEnum.GPU_IVF_PQ: {
-        const auto = params.indexParams.pqDim === PQ_DIM_AUTO;
-        return [
-          `nlist = ${formatGpuNumber(effectiveIndexParams.nlist)}`,
-          `pq_dim = ${formatGpuNumber(effectiveIndexParams.pqDim)}${
-            auto ? ' (cuVS Auto)' : ''
-          }`,
-          `nbits = ${effectiveIndexParams.pqBits}`,
-          `code = ${formatGpuNumber(
-            segmentIndexMemory.codeBytes || 0
-          )} B/vector`,
-        ].join(' · ');
-      }
-      case GpuIndexTypeEnum.GPU_CAGRA:
-        return [
-          `graph_degree = ${formatGpuNumber(effectiveIndexParams.graphDegree)}`,
-          `intermediate = ${formatGpuNumber(
-            effectiveIndexParams.intermediateDegree
-          )}`,
-        ].join(' · ');
-      default:
-        return t('gpu.result.noTunableParams');
-    }
-  }, [
-    indexType,
-    params.indexParams,
-    effectiveIndexParams,
-    segmentIndexMemory,
-    segmentRowCount,
-    t,
-  ]);
 
   const breakdownRows = useMemo(
     () =>
@@ -516,15 +473,6 @@ export default function GpuResultSection(props: GpuResultSectionProps) {
                   name={t('gpu.result.segmentCount')}
                   data={formatGpuNumber(segmentCount)}
                 />
-              </div>
-
-              <div className={clsx('mt-[16px]', classes.detailRow)}>
-                <span className={commonClasses.commonKeyLabel}>
-                  {t('gpu.result.effectiveParams')}
-                </span>
-                <span className={classes.detailValue}>
-                  {effectiveParamsLabel}
-                </span>
               </div>
 
               <p className={clsx('mt-[16px] mb-[8px]', classes.subTitle)}>


### PR DESCRIPTION
Follow-up to #2396.

Removes the **Effective index params** row from the GPU tab's Core Calculation section.

The clamping and auto-resolution behind it are unchanged — `nlist` is still capped at the segment row count and `pq_dim = 0` still resolves through the cuVS rule — the derived values simply are no longer surfaced as their own row. Everything else in Core Calculation (bytes per row, rows per segment, segment count, per-segment breakdown, lifecycle peak) is untouched.

`gpu-sizing-spec.md` is annotated so the doc no longer lists a row the UI does not render, while keeping the clamping rule itself documented.

Checked in the browser across all four index types: the row is gone, spacing closes up cleanly, no console errors. `tsc --noEmit` and Prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)