### PR TITLE
feat(llms): generate public/llms.txt from the docs tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "concurrently --names \"next,i18n\" --prefix-colors \"bgBlack.bold,bgCyan.bold\" \"npm run dev:fe\" \"npm run i18n:watch\"",
     "dev:fe": "node scripts/migrateAssets.js && next dev -p 8000",
-    "build": "node scripts/migrateAssets.js && node scripts/build.js",
+    "build": "node scripts/migrateAssets.js && node scripts/generate-llms-txt.js && node scripts/build.js",
     "postbuild": "next-sitemap --config sitemap.config.js",
     "start": "npx next start",
     "lint": "next lint",
@@ -15,6 +15,7 @@
     "i18n:scan": "node i18n-watcher/scan.js",
     "i18n:sync": "NODE_ENV=development node i18n-watcher/translate-changes.js",
     "generate:docs": "node scripts/generate-docs.js",
+    "generate:llms": "node scripts/generate-llms-txt.js",
     "test:inkeep": "npx playwright test tests/inkeep.test.js"
   },
   "dependencies": {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,343 +1,755 @@
 # Milvus
 
-> Milvus is an open-source, high-performance vector database designed for similarity search and AI applications. It supports billion-scale vector storage and search across deployment modes: Milvus Lite (embedded, for prototyping), Milvus Standalone (single-node, for small-scale production), and Milvus Distributed (Kubernetes, for enterprise scale). The primary SDK is PyMilvus for Python; Java, Go, Node.js, and RESTful SDKs are also available. Always check PyPI (`pip install --upgrade pymilvus`) or npm for the latest SDK version rather than relying on memorized version numbers.
+> Milvus is an open-source, high-performance vector database designed for similarity search and AI applications. It supports billion-scale vector storage and search across deployment modes: Milvus Lite (embedded, for prototyping), Milvus Standalone (single-node, for small-scale production), and Milvus Distributed (Kubernetes, for enterprise scale). The primary SDK is PyMilvus for Python; Java, Go, Node.js, and RESTful SDKs are also available.
 
-When writing code that uses Milvus, always use the `MilvusClient` interface introduced in v2.4+. Never use the legacy ORM API (`connections.connect()`, `Collection()`, `utility.list_collections()`). The ORM API is deprecated and will be removed in a future release. If you encounter existing code using the ORM API, advise the user to upgrade to the latest version of the SDKs and rewrite the code using `MilvusClient`.
+This index is generated from the Milvus v3.0.x documentation tree. Every URL below resolves to a published page.
 
-## Docs
+## URL rules
+
+Read this before citing any milvus.io URL.
+
+Documentation URLs take exactly one of these four forms:
+
+    https://milvus.io/docs/<page-id>                    latest version (v3.0.x), English
+    https://milvus.io/docs/<version>/<page-id>          pinned version
+    https://milvus.io/docs/<lang>/<page-id>             translated, latest version
+    https://milvus.io/docs/<lang>/<version>/<page-id>   translated, pinned version
+
+- `<page-id>` always ends in `.md` — for example `overview.md`. The suffix is
+  part of the route, not a file extension. `https://milvus.io/docs/overview` is a 404;
+  `https://milvus.io/docs/overview.md` is the page.
+- `<version>` is one of: v2.6.x, v2.5.x, v2.4.x. Omit the segment entirely for
+  the latest version (v3.0.x) — there is no `/docs/v3.0.x/` path.
+- `<lang>` is one of: zh, zh-hant, ja, ko, de, fr, es, it, pt, ru, ar, id. Omit the segment for English.
+- API reference URLs are `https://milvus.io/api-reference/<sdk>/<version>/<page>.md` and
+  are versioned separately from the docs; see the API Reference section.
+- Blog, AI Quick Reference, and Learn pages do not use a `.md` suffix.
+
+**Unknown paths return a hard 404 — they do not redirect and they do not fall
+back to a search page.** A URL that looks right but was never published is a
+dead link for the reader.
+
+Therefore: cite only page ids that appear in this file. If the page you need is
+not listed, say it is not in the index rather than assembling a plausible slug
+from the topic name. `https://milvus.io/sitemap.xml` enumerates every published URL and
+is the correct place to resolve anything this file does not cover.
+
+## Rules for generating Milvus code
+
+- Use the `MilvusClient` interface introduced in v2.4+. Do not use the legacy ORM API (`connections.connect()`, `Collection()`, `utility.list_collections()`) — it is deprecated and will be removed. If you find existing ORM code, advise upgrading the SDK and rewriting against `MilvusClient`.
+- Check PyPI (`pip install --upgrade pymilvus`) or npm for the current SDK version rather than relying on a memorized version number.
+- To change existing entities use `client.upsert()`. There is no `client.update()`. `upsert()` inserts when the primary key is absent and replaces the whole entity when it is present; use `client.insert()` only for data known not to collide.
+- A collection schema is immutable in v2.5.x and earlier — to change it, drop and recreate the collection. From v2.6+ you may add scalar fields with `add_collection_field()`, but vector fields cannot be added and existing fields cannot be modified or removed. Changing a field's data type is not supported in any version. Check the server version before suggesting a schema change.
+- Primary keys must be `DataType.INT64` or `DataType.VARCHAR`, must be unique across the whole collection including partitions, and cannot be composite.
+- For BM25 full-text search, the BM25 function and its analyzer must be declared when the collection is created; they cannot be added later.
+- A vector field must be indexed and the collection loaded before it can be searched.
+- In `client.hybrid_search()`, each `AnnSearchRequest` takes exactly one query vector — use one request per vector field — and each search accepts exactly one ranker. Rankers cannot be chained.
+- Search iterators (`with-iterators.md`) support basic ANN search only, not hybrid search.
+- Both scalar and vector fields support `nullable=True`; only Array of Structs fields (and any field nested inside one) cannot be nullable. A nullable field cannot be a partition key, nullability is fixed at field creation, and a nullable vector field cannot be filtered with `IS NULL` / `IS NOT NULL`. See `nullable-and-default.md`, which is authoritative here.
 
 ## About Milvus
 
-- [What is Milvus](https://milvus.io/docs/overview.md): Introduces Milvus as an open-source, high-performance vector database for similarity search and AI applications.
-- [Milvus Roadmap](https://milvus.io/docs/roadmap.md): Development roadmap outlining recent achievements and future feature plans.
-- [Releases](https://milvus.io/docs/release_notes.md): New features, improvements, bug fixes, and known issues in each Milvus release.
+- [What is Milvus](https://milvus.io/docs/overview.md): Milvus is a high-performance, highly scalable vector database that runs efficiently across a wide range of environments, from a laptop to large-scale…
+- [Milvus Adopters](https://milvus.io/docs/milvus_adopters.md): Learn about companies that have adopted Milvus in production applications.
+- [Milvus Roadmap](https://milvus.io/docs/roadmap.md): Milvus is an open-source vector database built to power AI applications. Here is our roadmap to guide our development.
+- [Releases](https://milvus.io/docs/release_notes.md): Milvus Release Notes
+- [Comparison](https://milvus.io/docs/comparison.md): This article compares Milvus with other vector search solutions.
 
 ## Get Started
 
-Start here for first-time setup. Begin with the Quickstart for a hands-on tutorial using Milvus Lite, then choose a deployment mode and install an SDK.
+Start here for first-time setup: run the Quickstart against Milvus Lite, then pick a deployment mode and install an SDK.
 
-- [Quickstart](https://milvus.io/docs/quickstart.md): Hands-on quickstart with Milvus Lite covering collection creation, vector insertion, and similarity search.
-- [Install Overview](https://milvus.io/docs/install-overview.md): Overview of deployment modes and installation options.
-- [Run Milvus Lite](https://milvus.io/docs/milvus_lite.md): Install and run the lightweight embedded Milvus for prototyping.
-- [Run Milvus Standalone - Requirements](https://milvus.io/docs/prerequisite-docker.md): Hardware and software requirements for Standalone deployment.
-- [Run Milvus Standalone - RPM/DEB](https://milvus.io/docs/install_standalone-binary.md): Install Milvus Standalone using RPM or DEB packages.
-- [Run Milvus Standalone - Docker (Linux)](https://milvus.io/docs/install_standalone-docker.md): Deploy Milvus Standalone on Linux using Docker.
-- [Run Milvus Standalone - Docker Compose (Linux)](https://milvus.io/docs/install_standalone-docker-compose.md): Deploy Milvus Standalone using Docker Compose on Linux.
-- [Run Milvus Standalone - Docker Desktop (Windows)](https://milvus.io/docs/install_standalone-windows.md): Run Milvus Standalone on Windows using Docker Desktop.
-- [Run Milvus Distributed - Requirements](https://milvus.io/docs/prerequisite-helm.md): Hardware and software requirements for distributed cluster deployment.
-- [Run Milvus Distributed - Milvus Operator](https://milvus.io/docs/install_cluster-milvusoperator.md): Deploy a Milvus cluster on Kubernetes using the Milvus Operator.
-- [Run Milvus Distributed - Helm Chart](https://milvus.io/docs/install_cluster-helm.md): Deploy a Milvus cluster on Kubernetes using Helm.
-- [Run Milvus with GPU - Requirements](https://milvus.io/docs/prerequisite-gpu.md): GPU hardware and driver requirements.
-- [Run Milvus with GPU - Helm Chart](https://milvus.io/docs/install_cluster-helm-gpu.md): Deploy Milvus with GPU support using Helm.
-- [Run Milvus with GPU - Docker Compose](https://milvus.io/docs/install_standalone-docker-compose-gpu.md): Deploy Milvus Standalone with GPU support using Docker Compose.
-- [Install PyMilvus](https://milvus.io/docs/install-pymilvus.md): Install the Python SDK (PyMilvus).
-- [Install Java SDK](https://milvus.io/docs/install-java.md): Install the Java SDK for Milvus.
-- [Install Go SDK](https://milvus.io/docs/install-go.md): Install the Go SDK for Milvus.
-- [Install Node.js SDK](https://milvus.io/docs/install-node.md): Install the Node.js SDK for Milvus.
-- [Connect to Milvus Server](https://milvus.io/docs/connect-to-milvus-server.md): How to establish connections to Milvus from different SDKs.
+- [Quickstart](https://milvus.io/docs/quickstart.md): Get started with Milvus.
+- [Connect to Milvus Server](https://milvus.io/docs/connect-to-milvus-server.md): This topic describes how to establish a client connection to a Milvus server and configure common connection options.
+
+### Install Milvus
+
+- [Overview](https://milvus.io/docs/install-overview.md): Milvus is a highly performant, scalable vector database.
+- [Run Milvus Lite](https://milvus.io/docs/milvus_lite.md): Get started with Milvus Lite.
+
+#### Run Milvus Standalone
+
+- [Requirements](https://milvus.io/docs/prerequisite-docker.md): Learn the necessary preparations before installing Milvus Standalone.
+- [RPM/DEB](https://milvus.io/docs/install_standalone-binary.md): Learn how to install Milvus standalone with a pre-built RPM/DEB package.
+- [Docker (Linux)](https://milvus.io/docs/install_standalone-docker.md): Learn how to install Milvus standalone with Docker.
+- [Docker Compose (Linux)](https://milvus.io/docs/install_standalone-docker-compose.md): Learn how to install Milvus standalone with Docker Compose.
+- [Docker Desktop (Windows)](https://milvus.io/docs/install_standalone-windows.md): Learn how to install Milvus standalone with Docker Desktop for Windows.
+
+#### Run Milvus Distributed
+
+- [Requirements](https://milvus.io/docs/prerequisite-helm.md): Learn the necessary preparations before installing Milvus with Helm.
+- [Milvus Operator](https://milvus.io/docs/install_cluster-milvusoperator.md): Learn how to install Milvus cluster on Kubernetes using Milvus Operator
+- [Helm Chart](https://milvus.io/docs/install_cluster-helm.md): Learn how to install Milvus cluster on Kubernetes.
+
+#### Run Milvus with GPU
+
+- [Requirements](https://milvus.io/docs/prerequisite-gpu.md): Learn the necessary preparations before installing Milvus with GPU.
+- [Helm Chart](https://milvus.io/docs/install_cluster-helm-gpu.md): Learn how to install Milvus cluster on Kubernetes.
+- [Docker Compose](https://milvus.io/docs/install_standalone-docker-compose-gpu.md): Learn how to install Milvus cluster on Kubernetes.
+
+### Install SDKs
+
+- [PyMilvus](https://milvus.io/docs/install-pymilvus.md): Learn how to install the Python SDK of Milvus.
+- [Java SDK](https://milvus.io/docs/install-java.md): Learn how to install the Java SDK of Milvus.
+- [Go SDK](https://milvus.io/docs/install-go.md): Learn how to install the GO SDK of Milvus.
+- [Node.js SDK](https://milvus.io/docs/install-node.md): Learn how to install the Node.js SDK of Milvus.
 
 ## Concepts
 
-Core concepts for understanding Milvus's data model, distance metrics, consistency guarantees, and multi-tenancy strategies.
-
-- [Metric Types](https://milvus.io/docs/metric.md): Distance metrics (L2, IP, COSINE, etc.) supported for vector similarity search.
-- [Similarity Metrics Visualized](https://milvus.io/learn-milvus/metric): Interactive playground showing how L2, cosine, and inner product change which neighbors count as nearest.
-- [Multi-tenancy](https://milvus.io/docs/multi_tenancy.md): Multi-tenancy support for isolating data across users or clients.
+- [Bitset](https://milvus.io/docs/bitset.md): Learn about bitsets in Milvus.
+- [Multi-tenancy](https://milvus.io/docs/multi_tenancy.md): In Milvus, multi-tenancy means multiple customers or teams—referred to as tenants— share the same cluster while maintaining isolated data environments.
+- [Timestamp](https://milvus.io/docs/timestamp.md): Learn about the concept of timestamp and the four main timestamp-related parameters in the Milvus vector database.
+- [Time Synchronization](https://milvus.io/docs/time_sync.md): Learn about the time synchronization system in Milvus.
+- [Metric Types](https://milvus.io/docs/metric.md): Similarity metrics are used to measure similarities among vectors.
+- [In-memory Replica](https://milvus.io/docs/replica.md): Learn about in-memory replica in Milvus.
 - [Terminology](https://milvus.io/docs/glossary.md): Glossary of Milvus-specific terms and definitions.
-- [In-memory Replica](https://milvus.io/docs/replica.md): In-memory replicas for higher availability and read throughput.
+
+### Architecture
+
+- [Overview](https://milvus.io/docs/architecture_overview.md): Milvus provides a fast, reliable, and stable vector database built specifically for similarity search and artificial intelligence.
+- [Main Components](https://milvus.io/docs/main_components.md): Learn about the main components in Milvus standalone and cluster.
+- [Streaming Service](https://milvus.io/docs/streaming_service.md): The Streaming Service is a concept for Milvus internal streaming system module, built around the Write-Ahead Log (WAL) to support various streaming-related…
+- [Data Processing](https://milvus.io/docs/data_processing.md): Learn about the data processing procedure in Milvus.
+- [Woodpecker](https://milvus.io/docs/woodpecker_architecture.md): Woodpecker is a cloud-native WAL system in Milvus 2.6.
+- [Knowhere](https://milvus.io/docs/knowhere.md): Learn about Knowhere in Milvus.
 
 ## User Guide
 
-## Database
+- [Database](https://milvus.io/docs/manage_databases.md): Milvus introduces a database layer above collections, providing a more efficient way to manage and organize your data while supporting multi-tenancy.
 
-- [Manage Databases](https://milvus.io/docs/manage_databases.md): Create, select, and manage databases (logical groups of collections).
+### Collections
 
-## Collections
+- [Collection Explained](https://milvus.io/docs/manage-collections.md): On Milvus, you can create multiple collections to manage your data, and insert your data as entities into the collections.
+- [Create Collection](https://milvus.io/docs/create-collection.md): You can create a collection by defining its schema, index parameters, metric type, and whether to load it upon creation.
+- [Create an External Collection](https://milvus.io/docs/create-an-external-collection.md): An external collection is a type of data collection in Milvus that accesses data from external storage systems or database tables such as AWS S3 and Iceberg…
+- [View Collections](https://milvus.io/docs/view-collections.md): You can obtain the name list of all the collections in the currently connected database, and check the details of a specific collection.
+- [Modify Collection](https://milvus.io/docs/modify-collection.md): You can rename a collection or change its settings. This page focuses on how to modify a collection.
+- [Load & Release](https://milvus.io/docs/load-and-release.md): Loading a collection is the prerequisite to conducting similarity searches and queries in collections.
+- [Set Collection TTL](https://milvus.io/docs/set-collection-ttl.md): Configure collection-level or entity-level TTL policies to expire stale data automatically in Milvus.
+- [Set Consistency Level](https://milvus.io/docs/tune_consistency.md): As a distributed vector database, Milvus offers multiple levels of consistency to ensure that each node or replica can access the same data during read and…
+- [Manage Partitions](https://milvus.io/docs/manage-partitions.md): A partition is a subset of a collection.
+- [Manage Aliases](https://milvus.io/docs/manage-aliases.md): Milvus provides alias management capabilities. This page demonstrates the procedures to create, list, alter, and drop aliases.
+- [Drop Collection](https://milvus.io/docs/drop-collection.md): You can drop a collection if it is no longer needed.
 
-Create and manage collections — the primary data container in Milvus, analogous to a table in a relational database. Each collection has a schema that defines its fields.
+### Schema & Data Fields
 
-- [Collection Explained](https://milvus.io/docs/manage-collections.md): Overview of collection lifecycle: create, list, load, release, and drop.
-- [Create Collection](https://milvus.io/docs/create-collection.md): Create a collection with a defined schema, index, and consistency level.
-- [View Collections](https://milvus.io/docs/view-collections.md): List and inspect existing collections.
-- [Modify Collection](https://milvus.io/docs/modify-collection.md): Modify collection properties such as TTL and consistency level.
-- [Load & Release](https://milvus.io/docs/load-and-release.md): Load a collection into memory before search, and release it to free resources.
-- [Set Collection TTL](https://milvus.io/docs/set-collection-ttl.md): Configure time-to-live for automatic data expiration.
-- [Set Consistency Level](https://milvus.io/docs/tune_consistency.md): Configure read consistency levels (strong, bounded, session, eventually).
-- [Manage Partitions](https://milvus.io/docs/manage-partitions.md): Create and manage partitions for data organization.
-- [Manage Aliases](https://milvus.io/docs/manage-aliases.md): Assign and manage aliases for easier collection reference.
-- [Drop Collection](https://milvus.io/docs/drop-collection.md): Permanently delete a collection and all its data.
+Schema changes are heavily constrained — see the schema and primary-key rules above before designing a collection.
 
-## Schema & Data Fields
+- [Schema Explained](https://milvus.io/docs/schema.md): A schema defines the data structure of a collection. Before creating a collection, you need to work out a design of its schema.
+- [Primary Field & AutoID](https://milvus.io/docs/primary-field.md): Every collection in Milvus must have a primary field to uniquely identify each entity.
+- [Dense Vector](https://milvus.io/docs/dense-vector.md): Dense vectors are numerical data representations widely used in machine learning and data analysis.
+- [Binary Vector](https://milvus.io/docs/binary-vector.md): Binary vectors are a special form of data representation that convert traditional high-dimensional floating-point vectors into binary vectors containing only…
+- [Sparse Vector](https://milvus.io/docs/sparse_vector.md): Sparse vectors are an important method of capturing surface-level term matching in information retrieval and natural language processing.
+- [String Field](https://milvus.io/docs/string.md): In Milvus, VARCHAR is the data type used for storing string data.
+- [Number Field](https://milvus.io/docs/number.md): A number field is a scalar field that stores numeric values.
+- [Array Field](https://milvus.io/docs/array_data_type.md): An ARRAY field stores an ordered set of elements of the same data type. Here's an example of how ARRAY fields store data:
+- [Array of Structs](https://milvus.io/docs/array-of-structs.md): Use StructArray fields to store ordered Struct elements with a shared schema of vector and scalar fields.
+- [Geometry Field](https://milvus.io/docs/geometry-field.md): When building applications like Geographic Information Systems (GIS), mapping tools, or location-based services, you often need to store and query geometric…
+- [TIMESTAMPTZ Field](https://milvus.io/docs/timestamptz-field.md): Applications that track time across regions, such as e-commerce systems, collaboration tools, or distributed logging, need precise handling of timestamps with…
+- [Dynamic Field](https://milvus.io/docs/enable-dynamic-field.md): Milvus allows you to insert entities with flexible, evolving structures through a special feature called the dynamic field.
+- [Nullable Fields](https://milvus.io/docs/nullable-and-default.md): Configure nullable fields and default values, including schema, insert, index, search, and filter behavior.
+- [Default Values](https://milvus.io/docs/default-values.md): Set default values for scalar fields so Milvus fills missing values during entity insertion.
+- [Alter Collection Field](https://milvus.io/docs/alter-collection-field.md): You can alter the properties of a collection field to change column constraints or enforce stricter data integrity rules.
+- [Add Fields to an Existing Collection](https://milvus.io/docs/add-fields-to-an-existing-collection.md): Milvus allows you to dynamically add new fields to existing collections, making it easy to evolve your data schema as your application needs change.
 
-Define the schema and fields in a collection. A collection schema is immutable after creation in Milvus v2.5.x and earlier — you cannot add, modify, or delete fields once the collection is created. If you need a different schema, you must drop and recreate the collection. In v2.6+, you can add new fields using `add_collection_field()` but cannot modify or delete existing fields. Primary keys must be either `DataType.INT64` or `DataType.VARCHAR` — composite primary keys are not supported. Primary keys must be unique across the entire collection, including across partitions. For full-text search using BM25, the BM25 function and text analyzer must be defined at collection creation time — they cannot be added afterward.
+#### JSON Field
 
-- [Schema Explained](https://milvus.io/docs/schema.md): Overview of collection schemas, field types, and constraints.
-- [Primary Field & AutoID](https://milvus.io/docs/primary-field.md): Configure the primary key field (INT64 or VARCHAR only) and auto-generated IDs.
-- [Dense Vector](https://milvus.io/docs/dense-vector.md): Configure dense (float) vector fields for similarity search.
-- [Binary Vector](https://milvus.io/docs/binary-vector.md): Configure binary vector fields for Hamming or Jaccard distance.
-- [Sparse Vector](https://milvus.io/docs/sparse_vector.md): Configure sparse vector fields for lexical or hybrid search.
-- [String Field](https://milvus.io/docs/string.md): Working with VARCHAR string fields and constraints.
-- [Number Field](https://milvus.io/docs/number.md): Working with integer and floating-point scalar fields.
-- [JSON Field Overview](https://milvus.io/docs/json-field-overview.md): Store and query semi-structured JSON data.
-- [JSON Indexing](https://milvus.io/docs/json-indexing.md): Create indexes on JSON field paths for efficient querying.
-- [JSON Shredding](https://milvus.io/docs/json-shredding.md): Automatically extract JSON fields into columnar storage for performance.
-- [Array Field](https://milvus.io/docs/array_data_type.md): Store and query fixed-type array fields.
-- [Array of Structs](https://milvus.io/docs/array-of-structs.md): Model arrays of structured objects using JSON fields.
-- [Geometry Field](https://milvus.io/docs/geometry-field.md): Store and query geospatial data.
-- [TIMESTAMPTZ Field](https://milvus.io/docs/timestamptz-field.md): Store timezone-aware timestamp data.
-- [Dynamic Field](https://milvus.io/docs/enable-dynamic-field.md): Enable dynamic fields to store key-value pairs without predefined schema.
-- [Nullable & Default](https://milvus.io/docs/nullable-and-default.md): Set fields as nullable or with default values. Note: vector, JSON, and Array fields do not support nullable.
-- [Analyzer Overview](https://milvus.io/docs/analyzer-overview.md): Configure text analyzers for full-text search and BM25. Must be defined at collection creation time.
-- [Multi-language Analyzers](https://milvus.io/docs/multi-language-analyzers.md): Analyzer support for multiple languages.
-- [Choose the Right Analyzer](https://milvus.io/docs/choose-the-right-analyzer-for-your-use-case.md): Guidance on selecting analyzers for your use case.
-- [Alter Collection Field](https://milvus.io/docs/alter-collection-field.md): Modify properties of existing fields.
-- [Add Fields to an Existing Collection](https://milvus.io/docs/add-fields-to-an-existing-collection.md): Add new fields to an existing collection (v2.6+ only).
-- [Data Model Design for Search](https://milvus.io/docs/schema-hands-on.md): Best practices for designing schemas optimized for search.
-- [Data Model Design with Array of Structs](https://milvus.io/docs/best-practices-for-array-of-structs.md): Best practices for modeling arrays of structured data.
+- [JSON Field Overview](https://milvus.io/docs/json-field-overview.md): When building applications like product catalogs, content management systems, or user preference engines, you often need to store flexible metadata alongside…
+- [JSON Indexing](https://milvus.io/docs/json-indexing.md): JSON fields provide a flexible way to store structured metadata in Milvus.
+- [JSON Shredding](https://milvus.io/docs/json-shredding.md): JSON shredding accelerates JSON queries by converting traditional row-based storage into optimized columnar storage.
 
-## Insert & Delete
+#### Analyzer
 
-Insert, upsert, and delete entities in a collection. To update existing entities, use `client.upsert()` — there is no `client.update()` method. The `upsert()` method inserts the entity if the primary key does not exist, or replaces the entire entity if it does. Use `client.insert()` only for new data that you are certain does not conflict with existing primary keys.
+- [Analyzer Overview](https://milvus.io/docs/analyzer-overview.md): In text processing, an analyzer is a crucial component that converts raw text into a structured, searchable format.
+- [Multi-language Analyzers](https://milvus.io/docs/multi-language-analyzers.md): When Milvus performs text analysis, it typically applies a single analyzer across an entire text field in a collection.
+- [Choose the Right Analyzer for Your Use Case](https://milvus.io/docs/choose-the-right-analyzer-for-your-use-case.md): Notes
+- [Manage File Resources](https://milvus.io/docs/manage-file-resources.md): Register and manage external dictionary files that Milvus text analyzers can load at runtime.
 
-- [Insert Entities](https://milvus.io/docs/insert-update-delete.md): Insert new entities into a collection.
-- [Upsert Entities](https://milvus.io/docs/upsert-entities.md): Insert or replace entities by primary key.
-- [Delete Entities](https://milvus.io/docs/delete-entities.md): Delete entities by primary key or filter expression.
+##### Built-in Analyzers
 
-## Indexes
+- [Standard](https://milvus.io/docs/standard-analyzer.md): The standard analyzer is the default analyzer in Milvus, which is automatically applied to text fields if no analyzer is specified.
+- [English](https://milvus.io/docs/english-analyzer.md): The english analyzer in Milvus is designed to process English text, applying language-specific rules for tokenization and filtering.
+- [Chinese](https://milvus.io/docs/chinese-analyzer.md): The chinese analyzer is designed specifically to handle Chinese text, providing effective segmentation and tokenization.
 
-Create and manage indexes on vector and scalar fields. An index must be created on vector fields before a collection can be loaded and searched. AUTOINDEX is recommended for most use cases.
+##### Tokenizers
 
-- [Index Explained](https://milvus.io/docs/index-explained.md): How indexing works in Milvus, including index types, parameters, and build process.
-- [Learn Milvus: Interactive Index Visualizations](https://milvus.io/learn-milvus): Interactive visualizations of how IVF, HNSW, and DiskANN indexes search, with tunable parameters.
-- [IVF Visualized](https://milvus.io/learn-milvus/ivf): Side-by-side FLAT vs IVF search animation with a live nprobe/recall tradeoff.
-- [HNSW Visualized](https://milvus.io/learn-milvus/hnsw): Step-by-step walk through the HNSW layered graph with tunable M and ef.
-- [DiskANN Visualized](https://milvus.io/learn-milvus/diskann): Animation of DiskANN's PQ-in-RAM beam search and SSD re-ranking.
-- [FLAT](https://milvus.io/docs/flat.md): Brute-force index for exact search on small datasets.
-- [IVF_FLAT](https://milvus.io/docs/ivf-flat.md): Inverted file index for memory-constrained scenarios.
-- [IVF_PQ](https://milvus.io/docs/ivf-pq.md): Inverted file index with product quantization for reduced memory.
-- [HNSW](https://milvus.io/docs/hnsw.md): Graph-based index for high-recall in-memory workloads.
-- [HNSW_SQ](https://milvus.io/docs/hnsw-sq.md): HNSW with scalar quantization for reduced memory.
-- [HNSW_PQ](https://milvus.io/docs/hnsw-pq.md): HNSW with product quantization for further memory reduction.
-- [DISKANN](https://milvus.io/docs/diskann.md): Disk-based index for datasets larger than RAM.
-- [SCANN](https://milvus.io/docs/scann.md): ScaNN index for fast approximate search.
-- [SPARSE_INVERTED_INDEX](https://milvus.io/docs/sparse-inverted-index.md): Index for sparse vector fields.
-- [BITMAP](https://milvus.io/docs/bitmap.md): Bitmap index for low-cardinality scalar fields.
-- [INVERTED](https://milvus.io/docs/inverted.md): Inverted index for scalar fields supporting term-level queries.
-- [GPU_CAGRA](https://milvus.io/docs/gpu-cagra.md): GPU-accelerated graph index.
-- [GPU_IVF_FLAT](https://milvus.io/docs/gpu-ivf-flat.md): GPU-accelerated IVF_FLAT index.
-- [GPU_IVF_PQ](https://milvus.io/docs/gpu-ivf-pq.md): GPU-accelerated IVF_PQ index.
-- [GPU_BRUTE_FORCE](https://milvus.io/docs/gpu-brute-force.md): GPU-accelerated brute-force search.
+- [Standard](https://milvus.io/docs/standard-tokenizer.md): The standard tokenizer in Milvus splits text based on spaces and punctuation marks, making it suitable for most languages.
+- [Whitespace](https://milvus.io/docs/whitespace-tokenizer.md): The whitespace tokenizer divides text into terms whenever there is a space between words.
+- [Jieba](https://milvus.io/docs/jieba-tokenizer.md): The jieba tokenizer processes Chinese text by breaking it down into its component words.
+- [Lindera](https://milvus.io/docs/lindera-tokenizer.md): The lindera tokenizer performs dictionary-based morphological analysis.
+- [ICU](https://milvus.io/docs/icu-tokenizer.md): The icu tokenizer is built on the Internationalization Components of Unicode (ICU) open‑source project, which provides key tools for software…
+- [Language Identifier](https://milvus.io/docs/language-identifier.md): The language_identifier is a specialized tokenizer designed to enhance the text search capabilities of Milvus by automating the language analysis process.
 
-## Search
+##### Filters
 
-Perform similarity search, filtered queries, and hybrid search. Always ensure the collection is loaded before searching. When using hybrid search (`client.hybrid_search()`), each `AnnSearchRequest` accepts exactly one query vector — you cannot pass multiple query vectors in a single sub-request. To search multiple vector fields, create one `AnnSearchRequest` per vector field. Each hybrid search operation accepts only one ranker (e.g., `WeightedRanker` or `RRFRanker`) — you cannot chain multiple rankers.
+- [Lowercase](https://milvus.io/docs/lowercase-filter.md): The lowercase filter converts terms generated by a tokenizer to lowercase, making searches case-insensitive.
+- [ASCII Folding](https://milvus.io/docs/ascii-folding-filter.md): The asciifolding filter converts characters outside the Basic Latin Unicode block (the first 127 ASCII characters) into their ASCII equivalents.
+- [Alphanumonly](https://milvus.io/docs/alphanumonly-filter.md): The alphanumonly filter removes tokens that contain non-ASCII characters, keeping only alphanumeric terms.
+- [Cnalphanumonly](https://milvus.io/docs/cnalphanumonly-filter.md): The cnalphanumonly filter removes tokens that contain any characters other than Chinese characters, English letters, or digits.
+- [Cncharonly](https://milvus.io/docs/cncharonly-filter.md): The cncharonly filter removes tokens that contain any non-Chinese characters.
+- [Length](https://milvus.io/docs/length-filter.md): The length filter removes tokens that do not meet specified length requirements, allowing you to control the length of tokens retained during text processing.
+- [Stop](https://milvus.io/docs/stop-filter.md): Use the stop filter to remove configured stop words from tokenized text during analysis.
+- [Decompounder](https://milvus.io/docs/decompounder-filter.md): Use the decompounder filter to split compound words with an inline dictionary or registered file resource.
+- [Stemmer](https://milvus.io/docs/stemmer-filter.md): The stemmer filter reduces words to their base or root form (known as stemming), making it easier to match words with similar meanings across different…
+- [Remove Punct](https://milvus.io/docs/removepunct-filter.md): The removepunct filter strips away punctuation marks, spaces, and line breaks that some tokenizers—such as jieba, lindera, and icu—normally keep.
+- [Regex](https://milvus.io/docs/regex-filter.md): The regex filter is a regular expression filter: any token produced by the tokenizer is kept only if it matches the expression you provide; everything else is…
+- [Synonym](https://milvus.io/docs/synonym-filter.md): Use the synonym filter to rewrite tokens with a synonym dictionary during text analysis.
 
-- [Basic ANN Search](https://milvus.io/docs/single-vector-search.md): Basic approximate nearest neighbor search on a single vector field.
-- [Filtered Search](https://milvus.io/docs/filtered-search.md): Combine vector similarity with scalar filter expressions.
-- [Range Search](https://milvus.io/docs/range-search.md): Search with distance constraints instead of top-K.
-- [Grouping Search](https://milvus.io/docs/grouping-search.md): Group search results by a scalar field value.
-- [Primary-Key Search](https://milvus.io/docs/primary-key-search.md): Retrieve entities directly by primary key.
-- [Hybrid Search](https://milvus.io/docs/multi-vector-search.md): Search across multiple vector fields and combine results with a ranker.
-- [Query](https://milvus.io/docs/get-and-scalar-query.md): Retrieve entities by filter expression without vector similarity.
-- [Filtering Explained](https://milvus.io/docs/boolean.md): Syntax reference for filter expressions used in search and query.
-- [Basic Operators](https://milvus.io/docs/basic-operators.md): Comparison, logical, and arithmetic operators for filter expressions.
-- [Filtering Templating](https://milvus.io/docs/filtering-templating.md): Use templates to construct dynamic filter expressions.
-- [JSON Operators](https://milvus.io/docs/json-operators.md): Operators for filtering on JSON fields.
-- [Array Operators](https://milvus.io/docs/array-operators.md): Operators for filtering on array fields.
-- [Random Sampling](https://milvus.io/docs/random-sampling.md): Randomly sample entities from a collection.
-- [Geometry Operators](https://milvus.io/docs/geometry-operators.md): Operators for geospatial filtering.
-- [Full Text Search](https://milvus.io/docs/full-text-search.md): BM25-based keyword search on text fields.
-- [Text Match](https://milvus.io/docs/keyword-match.md): Filter results by keyword matching on text fields.
-- [Text Highlighter](https://milvus.io/docs/text-highlighter.md): Highlight matching text in search results.
-- [Phrase Match](https://milvus.io/docs/phrase-match.md): Match exact phrases in text fields.
-- [Search with Embedding Lists](https://milvus.io/docs/search-with-embedding-lists.md): Search using multi-vector representations like ColBERT and ColPali.
-- [Elasticsearch Queries to Milvus](https://milvus.io/docs/elasticsearch-queries-to-milvus.md): Translate Elasticsearch queries to Milvus filter expressions.
-- [Search Iterators](https://milvus.io/docs/with-iterators.md): Iterate over large result sets. Supports basic ANN search only, not hybrid search.
-- [Use Partition Key](https://milvus.io/docs/use-partition-key.md): Use partition keys for efficient multi-tenant data isolation.
+#### Best Practices
 
-## Embeddings & Reranking
+- [Data Model Design for Search](https://milvus.io/docs/schema-hands-on.md): Information Retrieval systems, also known as search engines, are essential for various AI applications such as Retrieval-augmented generation (RAG), visual…
+- [Data Model Design with an Array of Structs](https://milvus.io/docs/best-practices-for-array-of-structs.md): Modern AI applications, especially in the Internet of Things (IoT) and autonomous driving, typically reason over rich, structured events: a sensor reading with…
 
-Built-in integration with embedding and reranking models.
+### Insert & Delete
 
-- [Embedding Function Overview](https://milvus.io/docs/embedding-function-overview.md): Overview of built-in embedding model integrations.
-- [OpenAI](https://milvus.io/docs/openai.md): Generate embeddings with OpenAI.
-- [Azure OpenAI](https://milvus.io/docs/azure-openai.md): Generate embeddings with Azure OpenAI.
-- [DashScope](https://milvus.io/docs/dashscope.md): Generate embeddings with DashScope.
-- [Bedrock](https://milvus.io/docs/bedrock.md): Generate embeddings with AWS Bedrock.
-- [Vertex AI](https://milvus.io/docs/vertex-ai.md): Generate embeddings with Google Vertex AI.
-- [Voyage AI](https://milvus.io/docs/voyage-ai.md): Generate embeddings with Voyage AI.
-- [Cohere](https://milvus.io/docs/cohere.md): Generate embeddings with Cohere.
-- [SiliconFlow](https://milvus.io/docs/siliconflow.md): Generate embeddings with SiliconFlow.
-- [Hugging Face TEI](https://milvus.io/docs/hugging-face-tei.md): Generate embeddings with Hugging Face Text Embeddings Inference.
-- [Weighted Ranker](https://milvus.io/docs/weighted-ranker.md): Combine search results using weighted scoring.
-- [RRF Ranker](https://milvus.io/docs/rrf-ranker.md): Combine search results using Reciprocal Rank Fusion.
-- [Boost Ranker](https://milvus.io/docs/boost-ranker.md): Apply field-specific boosting to search results.
-- [Decay Ranker Overview](https://milvus.io/docs/decay-ranker-overview.md): Apply time-decay or distance-decay functions to search results.
-- [Model Ranker Overview](https://milvus.io/docs/model-ranker-overview.md): Rerank search results using ML models (vLLM, TEI, Cohere, Voyage).
+Use `upsert()` to modify existing entities; `update()` does not exist.
 
-## Storage Optimization
+- [Insert Entities](https://milvus.io/docs/insert-update-delete.md): Entities in a collection are data records that share the same set of fields.
+- [Upsert Entities](https://milvus.io/docs/upsert-entities.md): The upsert operation provides a convenient way to insert or update entities in a collection.
+- [Delete Entities](https://milvus.io/docs/delete-entities.md): You can delete the entities that are no longer needed by filtering conditions or their primary keys.
 
-Optimize storage and memory usage for large-scale deployments.
+### Indexes
 
-- [Use mmap](https://milvus.io/docs/mmap.md): Memory-map data files to reduce memory usage.
-- [Clustering Compaction](https://milvus.io/docs/clustering-compaction.md): Compact data by clustering key for improved query performance.
-- [Tiered Storage Overview](https://milvus.io/docs/tiered-storage-overview.md): Separate hot and cold data across memory and disk tiers.
+A vector field must be indexed before the collection can be loaded and searched. AUTOINDEX is the right default for most workloads.
+
+- [Index Explained](https://milvus.io/docs/index-explained.md): An index is an additional structure built on top of data.
+
+#### Floating Vector Indexes
+
+- [FLAT](https://milvus.io/docs/flat.md): The FLAT index is one of the simplest and most straightforward methods for indexing and searching floating-point vectors.
+- [IVF_FLAT](https://milvus.io/docs/ivf-flat.md): The IVF_FLAT index is an indexing algorithm that can improve search performance for floating-point vectors.
+- [IVF_SQ8](https://milvus.io/docs/ivf-sq8.md): The IVF_SQ8 index is a quantization-based indexing algorithm designed to tackle large-scale similarity search challenges.
+- [IVF_PQ](https://milvus.io/docs/ivf-pq.md): The IVF_PQ index is a quantization-based indexing algorithm for approximate nearest neighbor search in high-dimensional spaces.
+- [IVF_RABITQ](https://milvus.io/docs/ivf-rabitq.md): The IVF_RABITQ index is a binary quantization-based indexing algorithm that quantizes FP32 vectors into binary representations.
+- [HNSW](https://milvus.io/docs/hnsw.md): The HNSW index is a graph-based indexing algorithm that can improve performance when searching for high-dimensional floating vectors.
+- [HNSW_SQ](https://milvus.io/docs/hnsw-sq.md): HNSW_SQ combines Hierarchical Navigable Small World (HNSW) graphs with Scalar Quantization (SQ), creating an advanced vector indexing method that offers a…
+- [HNSW_PQ](https://milvus.io/docs/hnsw-pq.md): HNSW_PQ leverages Hierarchical Navigable Small World (HNSW) graphs with Product Quantization (PQ), creating an advanced vector indexing method that offers a…
+- [HNSW_PRQ](https://milvus.io/docs/hnsw-prq.md): HNSW_PRQ leverages Hierarchical Navigable Small World (HNSW) graphs with Product Residual Quantization (PRQ), offering an advanced vector indexing method that…
+- [DISKANN](https://milvus.io/docs/diskann.md): In large-scale scenarios, where datasets can include billions or even trillions of vectors, standard in-memory indexing methods (e.g., HNSW, IVF_FLAT) often…
+- [SCANN](https://milvus.io/docs/scann.md): Powered by the ScaNN library from Google, the SCANN index in Milvus is designed to address scaling vector similarity search challenges, striking a balance…
+- [AISAQ](https://milvus.io/docs/aisaq.md): AISAQ is a disk-based vector index that extends DISKANN to handle billion-scale datasets without exceeding RAM limits.
+
+#### Binary Vector Indexes
+
+- [BIN_IVF_FLAT](https://milvus.io/docs/bin-ivf-flat.md): The BIN_IVF_FLAT index is a variant of the IVF_FLAT index exclusively for binary embeddings.
+- [BIN_FLAT](https://milvus.io/docs/bin-flat.md): The BIN_FLAT index is a variant of the FLAT index tailored exclusively for binary embeddings.
+- [MINHASH_LSH](https://milvus.io/docs/minhash-lsh.md): Use MinHash LSH indexes to speed up near-duplicate detection and Jaccard similarity search on large text datasets.
+
+#### Sparse Vector Indexes
+
+- [SPARSE_INVERTED_INDEX](https://milvus.io/docs/sparse-inverted-index.md): The SPARSE_INVERTED_INDEX index is an index type used by Milvus to efficiently store and search sparse vectors.
+
+#### Scalar Indexes
+
+- [BITMAP](https://milvus.io/docs/bitmap.md): Bitmap indexing is an efficient indexing technique designed to improve query performance on low-cardinality scalar fields.
+- [INVERTED](https://milvus.io/docs/inverted.md): When you need to perform frequent filter queries on your data, INVERTED indexes can dramatically improve query performance.
+- [NGRAM](https://milvus.io/docs/ngram.md): The NGRAM index in Milvus is built to accelerate LIKE queries on VARCHAR fields or specific JSON paths within JSON fields.
+- [RTREE](https://milvus.io/docs/rtree.md): The RTREE index is a tree-based data structure that accelerates queries on GEOMETRY fields in Milvus.
+- [STL_SORT](https://milvus.io/docs/stl-sort.md): The STL_SORT index is an index type specifically designed to enhance query performance on numeric fields (INT8, INT16, etc.), VARCHAR fields, or TIMESTAMPTZ…
+
+#### GPU-enabled Indexes
+
+- [GPU Index Overview](https://milvus.io/docs/gpu-index-overview.md): Building an index with GPU support in Milvus can significantly improve search performance in high-throughput and high-recall scenarios.
+- [GPU_CAGRA](https://milvus.io/docs/gpu-cagra.md): The GPU_CAGRA index is a graph-based index optimized for GPUs.
+- [GPU_IVF_FLAT](https://milvus.io/docs/gpu-ivf-flat.md): The GPU_IVF_FLAT index is a GPU-accelerated version of the IVF_FLAT index, designed exclusively for GPU environments.
+- [GPU_IVF_PQ](https://milvus.io/docs/gpu-ivf-pq.md): The GPU_IVF_PQ index builds on the IVF_PQ concept by combining inverted file clustering with Product Quantization (PQ), which breaks down high-dimensional…
+- [GPU_BRUTE_FORCE](https://milvus.io/docs/gpu-brute-force.md): Dedicated to GPU environments, the GPU_BRUTE_FORCE index is engineered for scenarios where uncompromising accuracy is essential.
+
+### Search
+
+Load the collection before searching. Hybrid search has per-request constraints — see the rules above.
+
+- [Basic ANN Search](https://milvus.io/docs/single-vector-search.md): Run basic ANN searches in Milvus with query vectors, output fields, filters, ranges, and iterators.
+- [Filtered Search](https://milvus.io/docs/filtered-search.md): An ANN search finds vector embeddings most similar to specified vector embeddings.
+- [Range Search](https://milvus.io/docs/range-search.md): A range search improves search result relevancy by restricting the distance or score of the returned entities within a specific range.
+- [Grouping Search](https://milvus.io/docs/grouping-search.md): Use grouping search to aggregate ANN search results by a field value and reduce duplicate entities.
+- [Primary-Key Search](https://milvus.io/docs/primary-key-search.md): When conducting similarity searches, you are always asked to provide one or more query vectors, even if the query vectors are already present in the target…
+- [Hybrid Search](https://milvus.io/docs/multi-vector-search.md): In many applications, an object can be searched by a rich set of information such as title and description, or with multiple modalities such as text, images,…
+- [Query](https://milvus.io/docs/get-and-scalar-query.md): Use Query, Get, and QueryIterator to retrieve entities, filter metadata, sort query results, and aggregate scalar values in Milvus.
+- [Full Text Search](https://milvus.io/docs/full-text-search.md): Full text search is a feature that retrieves documents containing specific terms or phrases in text datasets, then ranking the results based on relevance.
+- [Text Match](https://milvus.io/docs/keyword-match.md): Text match in Milvus enables precise document retrieval based on specific terms.
+- [Text Highlighter](https://milvus.io/docs/text-highlighter.md): The Highlighter in Milvus annotates matched terms in text fields by wrapping them with customizable tags.
+- [Phrase Match](https://milvus.io/docs/phrase-match.md): Phrase match lets you search for documents containing your query terms as an exact phrase.
+- [Search with Embedding Lists](https://milvus.io/docs/search-with-embedding-lists.md): This page explains how to set up a ColBERT text retrieval system and a ColPali text retrieval system using the array of structs in Milvus, which enables you to…
+- [Elasticsearch Queries to Milvus](https://milvus.io/docs/elasticsearch-queries-to-milvus.md): Elasticsearch, built on Apache Lucene, is a leading open-source search engine.
+- [Search Iterators](https://milvus.io/docs/with-iterators.md): The ANN Search has a maximum limit on the number of entities that can be recalled in a single query, and simply using basic ANN Search may not meet the demands…
+- [Use Partition Key](https://milvus.io/docs/use-partition-key.md): The Partition Key is a search optimization solution based on partitions.
+
+#### Filtering
+
+- [Filtering Explained](https://milvus.io/docs/boolean.md): Milvus provides powerful filtering capabilities that enable precise querying of your data.
+- [Basic Operators](https://milvus.io/docs/basic-operators.md): Milvus provides a rich set of basic operators to help you filter and query data efficiently.
+- [Filtering Templating](https://milvus.io/docs/filtering-templating.md): In Milvus, complex filter expressions with numerous elements, especially those involving non-ASCII characters like CJK characters, can significantly affect…
+- [JSON Operators](https://milvus.io/docs/json-operators.md): Milvus supports advanced operators for querying and filtering JSON fields, making them perfect for managing complex, structured data.
+- [Array Operators](https://milvus.io/docs/array-operators.md): Milvus provides powerful operators to query array fields, allowing you to filter and retrieve entities based on the contents of arrays.
+- [StructArray Operators](https://milvus.io/docs/struct-array-operators.md): Use element filters and match-family operators to filter scalar sub-fields inside StructArray fields.
+- [Random Sampling](https://milvus.io/docs/random-sampling.md): When working with large-scale datasets, you often don't need to process all your data to gain insights or test filtering logic.
+- [Geometry Operators](https://milvus.io/docs/geometry-operators.md): Milvus supports a set of operators for spatial filtering on GEOMETRY fields, which are essential for managing and analyzing geometric data.
+
+### Function & Model Inference
+
+- [BM25 Function](https://milvus.io/docs/bm25-function.md): The BM25 function enables full text search by transforming raw text into sparse vectors and scoring documents based on lexical relevance.
+- [MinHash Function](https://milvus.io/docs/minhash-function.md): Use MinHash to convert text into binary vectors for Jaccard-based similarity search and near-duplicate detection.
+
+#### Model-based Embedding Functions
+
+- [Embedding Function Overview](https://milvus.io/docs/embedding-function-overview.md): The Function module in Milvus allows you to transform raw text data into vector embeddings by automatically calling external embedding service providers (like…
+- [OpenAI](https://milvus.io/docs/openai.md): Use an OpenAI embedding model with Milvus by choosing a model and configuring Milvus with your OpenAI API key.
+- [Azure OpenAI](https://milvus.io/docs/azure-openai.md): This topic describes how to configure and use Azure OpenAI embedding functions in Milvus.
+- [DashScope](https://milvus.io/docs/dashscope.md): This topic describes how to configure and use DashScope embedding functions in Milvus.
+- [Bedrock](https://milvus.io/docs/bedrock.md): This topic describes how to configure and use Amazon Bedrock embedding functions in Milvus.
+- [Vertex AI](https://milvus.io/docs/vertex-ai.md): Google Cloud Vertex AI is a high-performance service specifically designed for text embedding models.
+- [Voyage AI](https://milvus.io/docs/voyage-ai.md): This topic describes how to configure and use Voyage AI embedding functions in Milvus.
+- [Cohere](https://milvus.io/docs/cohere.md): This topic describes how to configure and use Cohere embedding functions in Milvus.
+- [SiliconFLow](https://milvus.io/docs/siliconflow.md): This topic describes how to configure and use SiliconFLow embedding functions in Milvus.
+- [Hugging Face TEI](https://milvus.io/docs/hugging-face-tei.md): Hugging Face Text Embeddings Inference (TEI) is a high-performance inference server specifically designed for text embedding models.
+- [Google Gemini](https://milvus.io/docs/google-gemini.md): Use a Google Gemini embedding model with Milvus by choosing a model and configuring Milvus with your Gemini API key.
+
+#### Rerank Functions
+
+- [Weighted Ranker](https://milvus.io/docs/weighted-ranker.md): Weighted Ranker intelligently combines and prioritizes results from multiple search paths by assigning different importance weights to each.
+- [RRF Ranker](https://milvus.io/docs/rrf-ranker.md): Reciprocal Rank Fusion (RRF) Ranker is a reranking strategy for Milvus hybrid search that balances results from multiple vector search paths based on their…
+- [Boost Ranker](https://milvus.io/docs/boost-ranker.md): Instead of relying solely on semantic similarity calculated based on vector distances, Boost Rankers allow you to influence search results in a meaningful way.
+
+##### Decay Ranker
+
+- [Decay Ranker Overview](https://milvus.io/docs/decay-ranker-overview.md): In traditional vector search, results are ranked purely by vector similarity—how closely vectors match in mathematical space.
+- [Gaussian Decay](https://milvus.io/docs/gaussian-decay.md): Gaussian decay, also known as normal decay, creates the most natural-feeling adjustment to your search results.
+- [Exponential Decay](https://milvus.io/docs/exponential-decay.md): Exponential decay creates a steep initial drop followed by a long tail in your search results.
+- [Linear Decay](https://milvus.io/docs/linear-decay.md): Linear decay creates a straight-line decline that terminates at an absolute zero point in your search results.
+- [Tutorial: Implement Time-based Ranking in Milvus](https://milvus.io/docs/tutorial-implement-a-time-based-ranking-in-milvus.md): In many search applications, the freshness of content is just as important as its relevance.
+
+##### Model Ranker
+
+- [Model Ranker Overview](https://milvus.io/docs/model-ranker-overview.md): Traditional vector search ranks results purely by mathematical similarity—how closely vectors match in high-dimensional space.
+- [vLLM Ranker](https://milvus.io/docs/vllm-ranker.md): The vLLM Ranker leverages the vLLM inference framework to enhance search relevance through semantic reranking.
+- [TEI Ranker](https://milvus.io/docs/tei-ranker.md): The TEI Ranker leverages the Text Embedding Inference (TEI) service from Hugging Face to enhance search relevance through semantic reranking.
+- [Cohere Ranker](https://milvus.io/docs/cohere-ranker.md): The Cohere Ranker leverages Cohere's powerful rerank models to enhance search relevance through semantic reranking.
+- [Voyage AI Ranker](https://milvus.io/docs/voyage-ai-ranker.md): The Voyage AI Ranker leverages Voyage AI's specialized rerankers to enhance search relevance through semantic reranking.
+- [SiliconFlow Ranker](https://milvus.io/docs/siliconflow-ranker.md): The SiliconFlow Ranker leverages SiliconFlow's comprehensive reranking models to enhance search relevance through semantic reranking.
+
+### Storage Optimization
+
+- [Use mmap](https://milvus.io/docs/mmap.md): Memory mapping (Mmap) enables direct memory access to large files on disk, allowing Milvus to store indexes and data in both memory and hard drives.
+- [Clustering Compaction](https://milvus.io/docs/clustering-compaction.md): Clustering compaction is designed to improve search performance and reduce costs in large collections.
+- [Force Merge Compaction](https://milvus.io/docs/force-merge.md): Use force merge compaction to consolidate small segments and improve query performance and storage efficiency.
+
+#### Tiered Storage
+
+- [Tiered Storage Overview](https://milvus.io/docs/tiered-storage-overview.md): In Milvus, the traditional full-load mode requires each QueryNode to load all data fields and indexes of a segment at initialization, even data that may never…
+- [Warm Up](https://milvus.io/docs/warm-up.md): Warm Up complements Tiered Storage by preloading selected fields or indexes into the cache before a segment becomes queryable.
+- [Eviction](https://milvus.io/docs/eviction.md): Eviction manages the cache resources of each QueryNode in Milvus.
+
+### Snapshots
+
+- [Overview](https://milvus.io/docs/snapshots.md): Use snapshots to capture point-in-time collection states for rollback, versioning, and testing.
+- [Manage Snapshots](https://milvus.io/docs/manage-snapshots.md): In this guide, you will learn how to create and manage snapshots, including
+- [Use Cases](https://milvus.io/docs/snapshot-use-cases.md): In this guide, you will find common use cases for snapshots.
 
 ## Data Import
 
-Bulk import data into Milvus from external files for initial data loading.
+- [Prepare Source Data](https://milvus.io/docs/prepare-source-data.md): This page discusses something you should consider before you start bulk-inserting data into your collection.
+- [Import Data](https://milvus.io/docs/import-data.md): This page demonstrates the procedure to import the prepared data.
 
-- [Prepare Source Data](https://milvus.io/docs/prepare-source-data.md): Format source data files for bulk import.
-- [Import Data](https://milvus.io/docs/import-data.md): Execute bulk data import into Milvus.
+## AI Tools
+
+Written specifically for AI coding agents. `agents_overview.md` is a drop-in AGENTS.md for Milvus; read it before generating Milvus code.
+
+- [Milvus for AI Agents](https://milvus.io/docs/milvus_for_agents.md): Learn how AI agents can use Milvus as a vector database for RAG, semantic search, and long-term memory.
+
+### AI Prompts
+
+- [AGENTS.md for Milvus](https://milvus.io/docs/agents_overview.md): Rules and patterns for AI coding agents that generate, review, or debug Milvus vector database code using PyMilvus.
+- [Python SDK](https://milvus.io/docs/python_sdk.md): Rules for AI coding assistants to write correct Milvus Python code using MilvusClient.
+- [Schema Design](https://milvus.io/docs/schema_design.md): Rules for AI coding assistants to design correct Milvus collection schemas.
+- [Search Patterns](https://milvus.io/docs/search_patterns.md): Rules for AI coding assistants to implement search, hybrid search, and full-text search in Milvus.
+- [Index Selection](https://milvus.io/docs/index_selection.md): Rules for AI coding assistants to choose and configure Milvus indexes.
+- [RAG Pipeline](https://milvus.io/docs/rag_pipeline.md): Rules for AI coding assistants to build RAG pipelines with Milvus.
 
 ## Administration Guide
 
-Deploy, configure, scale, monitor, and secure Milvus in production environments.
+Deploying, configuring, scaling, monitoring, and securing Milvus in production. Downgrading across versions is not supported.
 
-- [Configure with Docker](https://milvus.io/docs/configure-docker.md): Configure Milvus parameters with Docker.
-- [Configure with Helm](https://milvus.io/docs/configure-helm.md): Configure Milvus parameters with Helm charts.
-- [Configure with Milvus Operator](https://milvus.io/docs/configure_operator.md): Configure Milvus parameters with the Operator.
-- [Allocate Resources](https://milvus.io/docs/allocate.md): Resource allocation and sizing for Milvus components.
-- [System Configurations](https://milvus.io/docs/system_configuration.md): System-level configuration reference.
-- [Dynamic Config](https://milvus.io/docs/dynamic_config.md): Change configuration parameters without restarting Milvus.
-- [Limit Collection Counts](https://milvus.io/docs/limit_collection_counts.md): Configure maximum number of collections.
-- [Coordinator HA](https://milvus.io/docs/coordinator_ha.md): Enable high availability for coordinator components.
-- [Deploy on AWS](https://milvus.io/docs/eks.md): Deploy Milvus on Amazon EKS.
-- [Deploy on GCP](https://milvus.io/docs/gcp.md): Deploy Milvus on Google Kubernetes Engine.
-- [Deploy on Azure](https://milvus.io/docs/azure.md): Deploy Milvus on Azure Kubernetes Service.
-- [Deploy on OpenShift](https://milvus.io/docs/openshift.md): Deploy Milvus on Red Hat OpenShift.
-- [Object Storage](https://milvus.io/docs/deploy_s3.md): Configure object storage (MinIO, S3, GCS, Azure Blob).
-- [Meta Storage](https://milvus.io/docs/deploy_etcd.md): Configure meta storage (etcd).
-- [Message Storage](https://milvus.io/docs/deploy_pulsar.md): Configure message storage (Pulsar, Kafka).
-- [Scale Cluster](https://milvus.io/docs/scaleout.md): Scale a Milvus cluster by adding or removing nodes.
-- [Scale Standalone](https://milvus.io/docs/scale-standalone.md): Scale resources for a Standalone deployment.
-- [Upgrade Milvus Cluster](https://milvus.io/docs/upgrade_milvus_cluster-operator.md): Upgrade a Milvus cluster to a newer version. Downgrading is not supported.
-- [Upgrade Milvus Standalone](https://milvus.io/docs/upgrade_milvus_standalone-operator.md): Upgrade Milvus Standalone to a newer version.
-- [Deploy Monitoring Services](https://milvus.io/docs/monitor.md): Set up Prometheus and Grafana for monitoring.
-- [Visualize Metrics](https://milvus.io/docs/visualize.md): Visualize Milvus metrics in Grafana dashboards.
-- [Create Alerts](https://milvus.io/docs/alert.md): Configure alerting rules for Milvus.
-- [Configure Access Logs](https://milvus.io/docs/configure_access_logs.md): Enable and configure access logging.
-- [Manage Resource Groups](https://milvus.io/docs/resource_group.md): Manage resource groups for workload isolation.
-- [Enable Authentication](https://milvus.io/docs/authenticate.md): Enable username/password authentication.
-- [RBAC Overview](https://milvus.io/docs/rbac.md): Role-based access control for fine-grained permissions.
-- [Grant Privileges](https://milvus.io/docs/grant_privileges.md): Grant specific operation privileges to roles.
-- [Grant Roles](https://milvus.io/docs/grant_roles.md): Assign roles to users.
-- [Encryption in Transit](https://milvus.io/docs/tls.md): Secure connections with TLS encryption.
-- [Milvus WebUI](https://milvus.io/docs/milvus-webui.md): Built-in web UI for monitoring system status.
+- [Milvus WebUI](https://milvus.io/docs/milvus-webui.md): Milvus Web UI is a graphical management tool for Milvus. It enhances system observability with a simple and intuitive interface.
+- [Woodpecker](https://milvus.io/docs/use-woodpecker.md): Learn how to enable woodpecker as the WAL in milvus.
+
+### Deployment
+
+#### On Premises
+
+- [With Docker](https://milvus.io/docs/configure-docker.md): Configure Milvus with Docker Compose.
+- [With Helm](https://milvus.io/docs/configure-helm.md): Configure Milvus with Helm Charts.
+- [With Milvus Operator](https://milvus.io/docs/configure_operator.md): Learn how to configure Milvus with Milvus Operator.
+- [Allocate Resources](https://milvus.io/docs/allocate.md): Learn how to allocate resources to Milvus on Kubernetes.
+
+#### On Clouds
+
+- [Deploy on AWS](https://milvus.io/docs/eks.md): Learn how to deploy a Milvus cluster on EKS
+- [Deploy on GCP](https://milvus.io/docs/gcp.md): Learn how to deploy a Milvus cluster on GKE.
+- [Deploy on Azure](https://milvus.io/docs/azure.md): Learn how to deploy a Milvus cluster on Azure.
+- [Deploy on OpenShift](https://milvus.io/docs/openshift.md): Learn how to deploy a Milvus cluster on OpenShift.
+
+##### Layer-7 Load Balacing
+
+- [AWS](https://milvus.io/docs/aws_layer7.md): Learn how to deploy a Milvus cluster behind a Layer-7 load balancer on AWS.
+- [GCP](https://milvus.io/docs/gcp_layer7.md): Learn how to deploy a Milvus cluster behind a Layer-7 load balancer on GCP.
+- [Azure](https://milvus.io/docs/ingress.md): Learn how to configure ingress nginx with Milvus.
+
+##### Cloud Storage
+
+- [AWS](https://milvus.io/docs/s3.md): Learn how to configure s3 with IAM Role.
+- [GCP](https://milvus.io/docs/gcs.md): Learn how to configure gcs with Workload Identity.
+- [Azure](https://milvus.io/docs/abs.md): Learn how to configure Blob Storage with Workload Identity.
+
+### Configuration
+
+- [System Configurations](https://milvus.io/docs/system_configuration.md): Learn about the system configuration of Milvus.
+- [On the Fly](https://milvus.io/docs/dynamic_config.md): Learn about the dynamic configuration of Milvus.
+- [Limit Collection Counts](https://milvus.io/docs/limit_collection_counts.md): Configure the maximum number of collections in an instance.
+- [Configure Chunk Cache](https://milvus.io/docs/chunk_cache.md): Tune the chunk cache that pre-loads data into memory ahead of search.
+- [Coordinator HA](https://milvus.io/docs/coordinator_ha.md): Learn about the motivation and procedure for Milvus coordinators to work in active standby.
+- [QueryNode Using Local Disk](https://milvus.io/docs/configure-querynode-localdisk.md): Learn how to configure Milvus QueryNode to use local disk.
+
+### Manage Dependencies
+
+#### With Docker or Helm
+
+- [Object Storage](https://milvus.io/docs/deploy_s3.md): Learn how to set up S3 storage for Milvus with Docker Compose or Helm.
+- [Meta Storage](https://milvus.io/docs/deploy_etcd.md): Learn how to configure meta storage for Milvus with Docker Compose/Helm.
+- [Message Storage](https://milvus.io/docs/deploy_pulsar.md): Learn how to configure message storage with Docker Compose or Helm.
+
+#### With Milvus Operator
+
+- [Object Storage](https://milvus.io/docs/object_storage_operator.md): Learn how to configure object storage with Milvus Operator.
+- [Meta Storage](https://milvus.io/docs/meta_storage_operator.md): Learn how to configure meta storage with Milvus Operator.
+- [Message Storage](https://milvus.io/docs/message_storage_operator.md): Learn how to configure message storage with Milvus Operator.
+
+#### Use Pulsar with Milvus
+
+- [Upgrade to Pulsar v3](https://milvus.io/docs/upgrade-pulsar-v3.md): Learn how to upgrade Pulsar from V2 to V3 in Milvus so that you can use the latest version of Milvus v2.5.x.
+- [Continue Using Pulsar v2](https://milvus.io/docs/use-pulsar-v2.md): Milvus recommands you to upgrade Pulsar to v3 for Milvus v2.5.x.
+
+### Scaling
+
+- [Scale Cluster](https://milvus.io/docs/scaleout.md): Learn how to manually or automatically scale out and scale in a Milvus cluster.
+- [Scale Standalone](https://milvus.io/docs/scale-standalone.md): Milvus Standalone is a single-machine server deployment.
+- [Scale with HPA](https://milvus.io/docs/hpa.md): Learn how to configure Horizontal Pod Autoscaling (HPA) to dynamically scale a Milvus cluster.
+- [Scale Dependencies](https://milvus.io/docs/scale-dependencies.md): Scale the etcd, object storage, and message queue dependencies.
+
+### Upgrade
+
+- [Upgrade Milvus Cluster](https://milvus.io/docs/upgrade_milvus_cluster-operator.md): Learn how to upgrade Milvus cluster with Milvus Operator.
+- [Upgrade Milvus Standalone](https://milvus.io/docs/upgrade_milvus_standalone-operator.md): Learn how to upgrade Milvus standalone with Milvus operator.
+
+### Monitoring, Alerts & Logs
+
+#### Monitoring
+
+- [Architecture](https://milvus.io/docs/monitor_overview.md): Learn how Prometheus and Grafana are used in Milvus for montoring and alerting services.
+- [Deploy Monitoring Services](https://milvus.io/docs/monitor.md): Learn how to deploy monitoring services for a Milvus cluster using Prometheus.
+- [Visualize Metrics](https://milvus.io/docs/visualize.md): Learn how to visualize Milvus metrics in Grafana.
+- [Milvus Metrics Dashboard](https://milvus.io/docs/metrics_dashboard.md): This topic introduces the monitoring metrics displayed in the Milvus Dashboard.
+
+#### Alerts
+
+- [Create an Alert](https://milvus.io/docs/alert.md): Learn how to create an alert for Milvus services in Grafana.
+
+#### Logs
+
+- [Configure Grafana Loki](https://milvus.io/docs/configure_grafana_loki.md): This topic describes how to collect logs using Loki and query logs for a Milvus cluster using Grafana.
+- [Configure Access Logs](https://milvus.io/docs/configure_access_logs.md): Enable and configure Milvus access logging.
+
+#### Trace
+
+- [Jaeger Tracing](https://milvus.io/docs/config_jaeger_tracing.md): This guide provides instructions on how to configure Jaeger to collect traces for Milvus.
+
+### Resource Groups
+
+- [Manage Resource Groups](https://milvus.io/docs/resource_group.md): Learn how to manage resource groups.
+
+### Security
+
+- [Enable Authentication](https://milvus.io/docs/authenticate.md): Learn how to manage user authentication in Milvus.
+- [Encryption in Transit](https://milvus.io/docs/tls.md): Learn how to enable TLS proxy in Milvus.
+- [Connect to Kafka with SASL/SSL](https://milvus.io/docs/connect_kafka_ssl.md): This guide lists several ways to connect Milvus to Kafka, from the simplest one without SASL/SSL to the fully secured one with SASL/SSL.
+
+#### Enable RBAC
+
+- [RBAC Overview](https://milvus.io/docs/rbac.md): RBAC (Role-Based Access Control) is an access control method based on roles.
+- [Users, Privileges, and Roles](https://milvus.io/docs/users_and_roles.md): Milvus achieves fine-grained access control through RBAC.
+- [Privilege Group](https://milvus.io/docs/privilege_group.md): To streamline the process of granting privileges, it is recommended that you combine multiple privileges into a privilege group.
+- [Grant Privileges](https://milvus.io/docs/grant_privileges.md): Once a role is created, you can grant privileges to the role. This guide introduces how to grant privileges or privilege groups to a role.
+- [Grant Roles](https://milvus.io/docs/grant_roles.md): After creating a role and granting privileges to the role, you can grant the role to users so that the users can access resources and perform actions that are…
+- [Drop Users & Roles](https://milvus.io/docs/drop_users_roles.md): To ensure data security, it is recommend that you drop users and roles that are no longer in use. This guide introduces how to drop users and roles.
+
+### Switch MQ Type
+
+- [Milvus Cluster switch MQ Type](https://milvus.io/docs/switch_milvus_cluster_mq_type-operator.md): Learn how to switch the message queue type for a Milvus cluster.
+- [Milvus Standalone switch MQ type](https://milvus.io/docs/switch_milvus_standalone_mq_type-operator.md): Learn how to switch the message queue type for Milvus standalone.
 
 ## Tools
 
-GUI, CLI, backup, and debugging tools for managing Milvus.
+- [SDK Code Helper (MCP)](https://milvus.io/docs/milvus-sdk-helper-mcp.md): ⚡️ Configure once, boost efficiency forever!
 
-- [Attu (Milvus GUI)](https://github.com/zilliztech/attu): GUI tool for managing Milvus instances, browsing collections, and running queries.
-- [Milvus Backup Overview](https://milvus.io/docs/milvus_backup_overview.md): Back up and restore collections using milvus-backup.
-- [Milvus Backup CLI](https://milvus.io/docs/milvus_backup_cli.md): Backup and restore commands reference.
-- [Birdwatcher Overview](https://milvus.io/docs/birdwatcher_overview.md): Debugging tool for inspecting Milvus internal state via etcd.
-- [Milvus CLI Overview](https://milvus.io/docs/cli_overview.md): Command-line tool for interacting with Milvus.
-- [Milvus CLI Commands](https://milvus.io/docs/cli_commands.md): CLI commands reference.
-- [Spark Connector](https://milvus.io/docs/integrate_with_spark.md): Bulk import data from Apache Spark.
-- [Milvus VTS](https://github.com/zilliztech/vts): Vector Transmission Service for data migration between collections.
-- [Milvus Sizing Tool](https://milvus.io/tools/sizing/): Estimate resource requirements for your deployment.
-- [SDK Code Helper (MCP)](https://milvus.io/docs/milvus-sdk-helper-mcp.md): MCP-based code generation helper for Milvus SDKs.
+### Milvus Backup
+
+- [Overview](https://milvus.io/docs/milvus_backup_overview.md): Milvus-Backup is a tool that allows users to backup and restore Milvus data.
+- [Commands](https://milvus.io/docs/milvus_backup_cli.md): Learn how to use Milvus Backup through CLI
+- [RESTful API](https://milvus.io/docs/milvus_backup_api.md): Learn how to use Milvus Backup through API
+
+#### Common Cases
+
+- [Backup and Restore in One Instance](https://milvus.io/docs/single-instance-backup-and-restore.md): This topic details the process of backing up a collection and restoring it from the backup within the same Milvus instance
+- [Migrate Between Instances in One Bucket](https://milvus.io/docs/shared-bucket-backup-and-restore.md): This topic details the process of backing up a collection from one Milvus instance and restoring it to another while using a shared bucket for object storage
+- [Migrate Between Instances Across Buckets](https://milvus.io/docs/cross-bucket-backup-and-restore.md): This topic details the process of backing up a collection from one Milvus instance and restoring it to another
+- [Migrate Between Instances Across S3 Environments](https://milvus.io/docs/multi-storage-backup-and-restore.md): This topic details the process of backing up a collection from one Milvus instance and restoring it to another
+
+### Birdwatcher
+
+- [Overview](https://milvus.io/docs/birdwatcher_overview.md): Birdwatcher is a debug tool for Milvus 2.x. It connects to etcd and inspects the status of the Milvus system.
+- [Install Guides](https://milvus.io/docs/birdwatcher_install_guides.md): Learn how to install Birdwatch to debug Milvus.
+- [Usage Guides](https://milvus.io/docs/birdwatcher_usage_guides.md): Learn how to use Birdwatch to debug Milvus.
+
+### Milvus CDC
+
+- [Overview](https://milvus.io/docs/milvus_cdc_overview.md): Milvus CDC replicates data changes from one Milvus cluster to another for primary-standby disaster recovery.
+- [Set Up CDC Replication](https://milvus.io/docs/set_up_cdc_replication.md): Learn how to deploy two Milvus clusters and configure CDC replication between them.
+- [Switchover](https://milvus.io/docs/cdc_switchover.md): Learn how to perform a planned switchover between primary and standby Milvus clusters with Milvus CDC.
+- [Failover](https://milvus.io/docs/cdc_failover.md): Learn how to perform a failover when the primary Milvus cluster becomes unavailable.
+
+### Milvus CLI
+
+- [Overview](https://milvus.io/docs/cli_overview.md): Milvus Command-Line Interface (CLI) is a command-line tool that supports database connection, data operations, and import and export of data.
+- [Installation](https://milvus.io/docs/install_cli.md): Learn how to install Milvus_CLI.
+- [Commands](https://milvus.io/docs/cli_commands.md): Interact with Milvus using commands.
+
+### Milvus Connectors
+
+- [Spark](https://milvus.io/docs/integrate_with_spark.md): Apache Spark and Databricks integrates with Milvus and Zilliz Cloud to combine big data processing with vector search.
+
+### Models
+
+#### Embeddings
+
+- [Overview](https://milvus.io/docs/embeddings.md): Learn how to generate embeddings for your data.
+- [OpenAI](https://milvus.io/docs/embed-with-openai.md): Milvus integrates with OpenAI's models via the OpenAIEmbeddingFunction class.
+- [Sentence Transformers](https://milvus.io/docs/embed-with-sentence-transform.md): This article demonstrates how to use Sentence Transformers in Milvus to encode documents and queries into dense vectors.
+- [BGE M3](https://milvus.io/docs/embed-with-bgm-m3.md): BGE-M3 is named for its capabilities in Multi-Linguality, Multi-Functionality, and Multi-Granularity.
+- [SPLADE](https://milvus.io/docs/embed-with-splade.md): This article describes how to use the SpladeEmbeddingFunction to encode documents and queries using the SPLADE model.
+- [Voyage](https://milvus.io/docs/embed-with-voyage.md): This article describes how to use the VoyageEmbeddingFunction to encode documents and queries using the Voyage model.
+- [Jina AI](https://milvus.io/docs/embed-with-jina.md): This article describes how to use the JinaEmbeddingFunction to encode documents and queries using the Jina AI embedding model.
+- [Cohere](https://milvus.io/docs/embed-with-cohere.md): This article describes how to use the CohereEmbeddingFunction to encode documents and queries using the Cohere embedding model.
+- [Instructor](https://milvus.io/docs/embed-with-instructor.md): This article describes how to use the InstructorEmbeddingFunction to encode documents and queries using the Instructor embedding model.
+- [Mistral AI](https://milvus.io/docs/embed-with-mistral-ai.md): This article describes how to use the MistralAIEmbeddingFunction to encode documents and queries using the Mistral AI embedding model.
+- [Nomic](https://milvus.io/docs/embed-with-nomic.md): This article describes how to use the NomicEmbeddingFunction to encode documents and queries using the Nomic embedding model.
+- [mGTE](https://milvus.io/docs/embed-with-mgte.md): This article describes how to use the MGTEEmbeddingFunction to encode documents and queries using the mGTE embedding model.
+- [Model2Vec](https://milvus.io/docs/embed-with-model2vec.md): Milvus integrates with Model2Vec's models via the Model2VecEmbeddingFunction class.
+- [Gemini](https://milvus.io/docs/embed-with-gemini.md): Milvus integrates with OpenAI's models via the GeminiEmbeddingFunction class.
+
+#### Rerankers
+
+- [Overview](https://milvus.io/docs/rerankers-overview.md): PyMilvus model library integrates rerank functions to optimize the order of results returned from initial searches.
+- [BGE](https://milvus.io/docs/rerankers-bge.md): Milvus supports BGE reranker models through the `BGERerankFunction` class.
+- [Cohere](https://milvus.io/docs/rerankers-cohere.md): Milvus supports Cohere reranker models through the `CohereRerankFunction` class.
+- [Cross Encoder](https://milvus.io/docs/rerankers-cross-encoder.md): Milvus supports Cross Encoder reranker models through the `CrossEncoderRerankFunction` class.
+- [Voyage](https://milvus.io/docs/rerankers-voyage.md): Milvus supports Voyage reranker model through the `VoyageRerankFunction` class.
+- [Jina AI](https://milvus.io/docs/rerankers-jina.md): Milvus supports Jina reranker model through the `JinaRerankFunction` class.
 
 ## Integrations
 
-Connect Milvus with popular AI frameworks, orchestration tools, LLMs, embedding providers, and data platforms.
+- [Overview](https://milvus.io/docs/integrations_overview.md): This page provides a list of tutorials for you to interact with Milvus and third-party tools.
 
-- [Integrations Overview](https://milvus.io/docs/integrations_overview.md): Overview of all supported integrations.
-- [LangChain - Basic Usage](https://milvus.io/docs/basic_usage_langchain.md): Basic Milvus vector store usage with LangChain.
-- [LangChain - RAG](https://milvus.io/docs/integrate_with_langchain.md): Build RAG pipelines with LangChain and Milvus.
-- [LangChain - Hybrid Search](https://milvus.io/docs/milvus_hybrid_search_retriever.md): Hybrid search retriever with LangChain.
-- [LlamaIndex - RAG](https://milvus.io/docs/integrate_with_llamaindex.md): Use Milvus as a vector store in LlamaIndex.
-- [DSPy](https://milvus.io/docs/integrate_with_dspy.md): Use Milvus as a retriever in DSPy.
-- [Haystack - RAG](https://milvus.io/docs/integrate_with_haystack.md): Use Milvus with Haystack for RAG pipelines.
-- [Dify](https://milvus.io/docs/dify_with_milvus.md): Use Milvus as the vector store backend in Dify.
-- [Langflow](https://milvus.io/docs/rag_with_langflow.md): Build RAG pipelines with Langflow and Milvus.
-- [Llama Stack](https://milvus.io/docs/llama_stack_with_milvus.md): Use Milvus with Meta's Llama Stack.
-- [n8n](https://milvus.io/docs/milvus_and_n8n.md): Use Milvus with n8n workflow automation.
-- [MemGPT](https://milvus.io/docs/integrate_with_memgpt.md): Use Milvus for long-term memory in MemGPT agents.
-- [Mem0](https://milvus.io/docs/quickstart_mem0_with_milvus.md): Use Milvus with Mem0 for agent memory.
-- [OpenAI Agents](https://milvus.io/docs/openai_agents_milvus.md): Use Milvus with OpenAI Agents SDK.
-- [MCP](https://milvus.io/docs/milvus_and_mcp.md): Use Milvus with Model Context Protocol.
-- [Ragas](https://milvus.io/docs/integrate_with_ragas.md): Evaluate RAG pipelines using Ragas.
-- [LangFuse](https://milvus.io/docs/integrate_with_langfuse.md): Observe and debug LLM applications with LangFuse.
-- [OpenAI Embeddings](https://milvus.io/docs/integrate_with_openai.md): Generate embeddings with OpenAI.
-- [Cohere Embeddings](https://milvus.io/docs/integrate_with_cohere.md): Generate embeddings with Cohere.
-- [HuggingFace](https://milvus.io/docs/integrate_with_hugging-face.md): Generate embeddings with HuggingFace models.
-- [SentenceTransformers](https://milvus.io/docs/integrate_with_sentencetransformers.md): Generate embeddings with Sentence Transformers.
-- [vLLM](https://milvus.io/docs/milvus_rag_with_vllm.md): Build RAG with vLLM and Milvus.
-- [Ollama](https://milvus.io/docs/build_RAG_with_milvus_and_ollama.md): Build RAG with Ollama and Milvus.
-- [DeepSeek](https://milvus.io/docs/build_RAG_with_milvus_and_deepseek.md): Build RAG with DeepSeek and Milvus.
-- [Gemini](https://milvus.io/docs/build_RAG_with_milvus_and_gemini.md): Build RAG with Gemini and Milvus.
-- [Airbyte](https://milvus.io/docs/integrate_with_airbyte.md): Ingest data from various sources via Airbyte.
-- [Kafka](https://milvus.io/docs/kafka-connect-milvus.md): Stream data from Kafka into Milvus.
-- [Firecrawl](https://milvus.io/docs/build_RAG_with_milvus_and_firecrawl.md): Crawl web pages and build RAG with Firecrawl.
-- [Unstructured](https://milvus.io/docs/rag_with_milvus_and_unstructured.md): Process unstructured documents for RAG.
+### Orchestration
+
+- [DSPy](https://milvus.io/docs/integrate_with_dspy.md): This guide demonstrates how to use MilvusRM, one of DSPy's retriever modules, to optimize RAG programs.
+- [FastGPT](https://milvus.io/docs/integrate_with_fastgpt.md): This tutorial will guide you on how to swiftly deploy your own exclusive FastGPT application using Milvus.
+- [Kotaemon](https://milvus.io/docs/kotaemon_with_milvus.md): This tutorial will guide you on how to customize your kotaemon application using Milvus.
+- [Dify](https://milvus.io/docs/dify_with_milvus.md): In this tutorial, we will show you how to deploy Dify with Milvus, to enable efficient retrieval and RAG engine.
+- [Langflow](https://milvus.io/docs/rag_with_langflow.md): This guide demonstrates how to use Langflow to build a Retrieval-Augmented Generation (RAG) pipeline with Milvus.
+- [DocsGPT](https://milvus.io/docs/use_milvus_in_docsgpt.md): In this tutorial, we will show you how to use Milvus as the backend vector database for DocsGPT.
+- [PrivateGPT](https://milvus.io/docs/use_milvus_in_private_gpt.md): In this tutorial, we will show you how to use Milvus as the backend vector database for PrivateGPT.
+- [Dynamiq](https://milvus.io/docs/milvus_rag_with_dynamiq.md): In this tutorial, we’ll explore how to seamlessly use Dynamiq with Milvus, the high-performance vector database purpose-built for RAG workflows.
+- [Llama Stack](https://milvus.io/docs/llama_stack_with_milvus.md): This tutorial introduces how to build a Llama Stack Server configured with Milvus, enabling you to import your private data to serve as your knowledge base.
+- [n8n](https://milvus.io/docs/milvus_and_n8n.md): n8n is a powerful open-source workflow automation platform that allows you to connect various applications, services, and APIs together to create automated…
+- [AnythingLLM](https://milvus.io/docs/use_milvus_in_anythingllm.md): This guide will walk you through configuring Milvus as the vector database in AnythingLLM, enabling you to embed, store, and search your documents for…
+
+#### LangChain
+
+- [Basic Usage](https://milvus.io/docs/basic_usage_langchain.md): This notebook shows how to use functionality related to the Milvus vector database.
+- [Text Embedding](https://milvus.io/docs/langchain_milvus_dido.md): This guide demonstrates how to use Milvus 2.6's Text Embedding Function (also known as Data In Data Out) with LangChain.
+- [RAG](https://milvus.io/docs/integrate_with_langchain.md): This guide demonstrates how to build a Retrieval-Augmented Generation (RAG) system using LangChain and Milvus.
+- [Hybrid Search](https://milvus.io/docs/milvus_hybrid_search_retriever.md): This notebook shows how to use functionality related to the Milvus vector database.
+- [Full-text Search](https://milvus.io/docs/full_text_search_with_langchain.md): This tutorial will show how to use LangChain and Milvus to implement full-text search in your application.
+- [Asynchronous Search](https://milvus.io/docs/langchain_milvus_async.md): This tutorial explores how to leverage asynchronous functions in langchain-milvus to build high-performance applications.
+- [Agent RAG](https://milvus.io/docs/agentic_rag_with_milvus_and_langgraph.md): This guide demonstrates how to build an advanced Retrieval-Augmented Generation (RAG) system using LangGraph and Milvus.
+
+#### LlamaIndex
+
+- [RAG](https://milvus.io/docs/integrate_with_llamaindex.md): This guide demonstrates how to build a Retrieval-Augmented Generation (RAG) system using LlamaIndex and Milvus.
+- [Milvus Async API](https://milvus.io/docs/llamaindex_milvus_async.md): This tutorial demonstrates how to use LlamaIndex with Milvus to build asynchronous document processing pipeline for RAG.
+- [Full-text Search](https://milvus.io/docs/llamaindex_milvus_full_text_search.md): In this tutorial, you'll learn how to use LlamaIndex and Milvus to build a RAG system using full-text search and hybrid search.
+- [Hybrid Search](https://milvus.io/docs/llamaindex_milvus_hybrid_search.md): This notebook demonstrates how to use Milvus for hybrid search in LlamaIndex RAG pipelines.
+- [Metadata Filtering](https://milvus.io/docs/llamaindex_milvus_metadata_filter.md): This notebook illustrates the use of the Milvus vector store in LlamaIndex, focusing on metadata filtering capabilities.
+
+#### HayStack
+
+- [RAG](https://milvus.io/docs/integrate_with_haystack.md): This guide demonstrates how to build a Retrieval-Augmented Generation (RAG) system using Haystack and Milvus.
+- [Full-text Search](https://milvus.io/docs/full_text_search_with_milvus_and_haystack.md): This tutorial demonstrates how to implement full-text and hybrid search in your application using Haystack and Milvus.
+
+### Agents
+
+- [MemGPT](https://milvus.io/docs/integrate_with_memgpt.md): MemGPT makes it easy to build and deploy stateful LLM agents. With Milvus integration, you can build agents with connections to external data sources (RAG).
+- [Camel](https://milvus.io/docs/integrate_with_camel.md): This guide demonstrates how to build a Retrieval-Augmented Generation (RAG) system using CAMEL and Milvus.
+- [Mem0](https://milvus.io/docs/quickstart_mem0_with_milvus.md): In this tutorial, we’ll cover essential Mem0 memory management operations—adding, retrieving, updating, searching, deleting, and tracking memory history—using…
+- [Agno](https://milvus.io/docs/integrate_with_agno.md): Milvus vector database enable efficient storage and retrieval of information as embeddings.
+- [OpenAI](https://milvus.io/docs/openai_agents_milvus.md): This notebook shows how to create an agent that can query Milvus using natural language through Function Calling.
+- [MCP](https://milvus.io/docs/milvus_and_mcp.md): This tutorial walks you through setting up an MCP server for Milvus, allowing AI applications to perform vector searches, manage collections, and retrieve data…
+
+### Evaluation & Observability
+
+- [Ragas](https://milvus.io/docs/integrate_with_ragas.md): This guide demonstrates how to use Ragas to evaluate a Retrieval-Augmented Generation (RAG) pipeline built upon Milvus.
+- [LangFuse](https://milvus.io/docs/integrate_with_langfuse.md): This is a simple cookbook that demonstrates how to use the LlamaIndex Langfuse integration. It uses Milvus Lite to store the documents and Query.
+- [FiftyOne](https://milvus.io/docs/integrate_with_voxel51.md): This page discusses the integration with voxel51
+- [Arize Pheonix](https://milvus.io/docs/evaluation_with_phoenix.md): This guide demonstrates how to use Arize Pheonix to evaluate a Retrieval-Augmented Generation (RAG) pipeline built upon Milvus.
+- [DeepEval](https://milvus.io/docs/evaluation_with_deepeval.md): This guide demonstrates how to use DeepEval to evaluate a Retrieval-Augmented Generation (RAG) pipeline built upon Milvus.
+- [AIMon](https://milvus.io/docs/AIMon_milvus_integration.md): In this tutorial, we'll help you build a retrieval-augmented generation (RAG) chatbot that answers questions.
+
+### Embedding Models
+
+- [OpenAI](https://milvus.io/docs/integrate_with_openai.md): This page discusses vector database integration with OpenAI's embedding API.
+- [Cohere](https://milvus.io/docs/integrate_with_cohere.md): This page illustrates how to create a question-answering system based on the SQuAD dataset using Milvus as the vector database and Cohere as the embedding…
+- [HuggingFace](https://milvus.io/docs/integrate_with_hugging-face.md): This tutorial shows how to build a question answering system using Hugging Face as the data loader & embedding generator for data processing and Milvus as the…
+- [PyTorch](https://milvus.io/docs/integrate_with_pytorch.md): This page demostrates how to build image search with PyTorch and Milvus
+- [SentenceTransformers](https://milvus.io/docs/integrate_with_sentencetransformers.md): This page discusses movie search using Milvus
+- [VoyageAI](https://milvus.io/docs/integrate_with_voyageai.md): This page discusses vector database integration with VoyageAI's embedding API.
+- [Jina AI](https://milvus.io/docs/integrate_with_jina.md): This guide demonstrates how to use Jina embeddings and Milvus to conduct similarity search and retrieval tasks.
+- [Twelve Labs](https://milvus.io/docs/video_search_with_twelvelabs_and_milvus.md): Learn how to create a semantic video search application by integrating Twelve Labs' Embed API for generating multimodal embeddings with Milvus.
+- [BentoML](https://milvus.io/docs/integrate_with_bentoml.md): This guide demonstrates how to use an open-source embedding model and large-language model on BentoCloud with Milvus vector database to build a Retrieval…
+- [EmbedAnything](https://milvus.io/docs/build_RAG_with_milvus_and_embedAnything.md): In this tutorial, we’ll demonstrate how to build a Retrieval-Augmented Generation (RAG) pipeline using EmbedAnything together with Milvus.
+
+### LLMs
+
+- [vLLM](https://milvus.io/docs/milvus_rag_with_vllm.md): This blog will show you how to build and run a RAG with Milvus, vLLM, and Llama 3.1.
+- [Mistral AI](https://milvus.io/docs/llama_agents_metadata.md): In this Notebook, we will explore different ideas: Store data into Milvus, use llama-index with Mistral models for data queries, create automated data search…
+- [Fireworks](https://milvus.io/docs/build_RAG_with_milvus_and_fireworks.md): In this tutorial, we will show you how to build a RAG (Retrieval-Augmented Generation) pipeline with Milvus and Fireworks AI.
+- [SiliconFlow](https://milvus.io/docs/build_RAG_with_milvus_and_siliconflow.md): In this tutorial, we will show you how to build a RAG(Retrieval-Augmented Generation) pipeline with Milvus and SiliconFlow.
+- [SambaNova](https://milvus.io/docs/use_milvus_with_sambanova.md): This tutorial leverages Milvus integration in SambaNova AI Starter Kits to build an Enterprise Knowledge Retrieval system, similar to RAG(Retrieval-Augmented…
+- [Gemini](https://milvus.io/docs/build_RAG_with_milvus_and_gemini.md): In this tutorial, we will show you how to build a RAG (Retrieval-Augmented Generation) pipeline with Milvus and Gemini.
+- [Ollama](https://milvus.io/docs/build_RAG_with_milvus_and_ollama.md): In this guide, we’ll show you how to leverage Ollama and Milvus to build a RAG (Retrieval-Augmented Generation) pipeline efficiently and securely.
+- [DeepSeek](https://milvus.io/docs/build_RAG_with_milvus_and_deepseek.md): In this tutorial, we’ll show you how to build a Retrieval-Augmented Generation (RAG) pipeline using Milvus and DeepSeek.
+
+### Knowledge Engineering
+
+- [WhyHow](https://milvus.io/docs/integrate_with_whyhow.md): This guide demonstrates how to use whyhow.ai and Milvus Lite to conduct Rule-based Retrieval.
+- [Vanna](https://milvus.io/docs/integrate_with_vanna.md): This guide demonstrates how to use Vanna to generate and execute SQL queries based on your data stored in a database.
+- [Knowledge Table](https://milvus.io/docs/knowledge_table_with_milvus.md): By default, Knowledge Table uses the Milvus database to store and retrieve the extracted data.
+- [Cognee](https://milvus.io/docs/build_RAG_with_milvus_and_cognee.md): In this tutorial, we will show you how to build a RAG (Retrieval-Augmented Generation) pipeline with Milvus and Cognee.
+- [MindsDB](https://milvus.io/docs/integration_with_mindsdb.md): This tutorial demonstrates how to integrate Milvus with MindsDB, enabling you to leverage MindsDB's AI capabilities with Milvus's vector database functionality…
+
+### Data Sources
+
+- [Airbyte](https://milvus.io/docs/integrate_with_airbyte.md): Airbyte is an open-source data movement infrastructure for building extract and load (EL) data pipelines.
+- [Kafka](https://milvus.io/docs/kafka-connect-milvus.md): Apache Kafka is integrated with Milvus and Zilliz Cloud to stream vector data.
+- [Apify](https://milvus.io/docs/apify_milvus_rag.md): This tutorial explains how to crawl websites using Apify's Website Content Crawler and save the data into Milvus/Zilliz vector database to be later used for…
+- [Unstructured](https://milvus.io/docs/rag_with_milvus_and_unstructured.md): In this tutorial, we will use Unstructured to ingest PDF documents and then use Milvus to build a RAG pipeline.
+- [PII Masker](https://milvus.io/docs/RAG_with_pii_and_milvus.md): In this tutorial, we will show you how to build a RAG(Retrieval-Augmented Generation) pipeline with Milvus and PII Masker.
+- [Firecrawl](https://milvus.io/docs/build_RAG_with_milvus_and_firecrawl.md): In this tutorial, we’ll show you how to build a Retrieval-Augmented Generation (RAG) pipeline using Milvus and Firecrawl.
+- [Crawl4AI](https://milvus.io/docs/build_RAG_with_milvus_and_crawl4ai.md): In this tutorial, we’ll show you how to build a Retrieval-Augmented Generation (RAG) pipeline using Milvus and Crawl4AI.
+- [AWS S3](https://milvus.io/docs/build_RAG_from_s3_with_milvus.md): This tutorial walks you through the process of building a Retrieval-Augmented Generation (RAG) pipeline using Milvus and Amazon S3.
+- [VectorETL](https://milvus.io/docs/ETL_using_vectorETL.md): In this tutorial, we'll explore how to efficiently load data into Milvus using VectorETL, a lightweight ETL framework designed for vector databases.
+- [Feast](https://milvus.io/docs/build_RAG_with_milvus_and_feast.md): In this tutorial, we will build a Retrieval-Augmented Generation (RAG) pipeline using Feast and Milvus.
+- [Mistral OCR](https://milvus.io/docs/mistral_ocr_with_milvus.md): This tutorial demonstrates how to build a document understanding system using Milvus and Mistral OCR.
+- [Docling](https://milvus.io/docs/build_RAG_with_milvus_and_docling.md): In this tutorial, we’ll show you how to build a Retrieval-Augmented Generation (RAG) pipeline using Milvus and Docling.
+- [NLWeb](https://milvus.io/docs/NLWeb_with_milvus.md): Learn how to integrate Microsoft NLWeb with Milvus to build powerful natural language interfaces for websites.
+- [LangExtract](https://milvus.io/docs/langextract_milvus_demo.md): This guide demonstrates how to use LangExtract with Milvus to build an intelligent document processing and retrieval system.
+- [Exa](https://milvus.io/docs/build_RAG_with_milvus_and_exa.md): This tutorial demonstrates how to build an agent that searches both the public web (via Exa) and a private knowledge base (via Milvus), then synthesizes a…
+
+### Others
+
+- [Snowflake](https://milvus.io/docs/integrate_with_snowpark.md): This guide demonstrates how to start a Milvus demo on Snowpark container services.
+- [Arm](https://milvus.io/docs/build_rag_on_arm.md): In this tutorial, you learn how to build a Retrieval-Augmented Generation (RAG) application on Arm-based infrastructures.
 
 ## Tutorials
 
-End-to-end tutorials and example applications demonstrating common use cases.
+- [Overview](https://milvus.io/docs/tutorials-overview.md): This page provides a list of tutorials for you to interact with Milvus.
+- [Build RAG with Milvus](https://milvus.io/docs/build-rag-with-milvus.md): build rag with milvus
+- [Advanced RAG](https://milvus.io/docs/how_to_enhance_your_rag.md): With the increasing popularity of Retrieval Augmented Generation RAG applications, there is a growing concern about improving their performance.
+- [Full-Text Search with Milvus](https://milvus.io/docs/full_text_search_with_milvus.md): Full-text search is a traditional method for retrieving documents by matching specific keywords or phrases in the text.
+- [Hybrid Search with Milvus](https://milvus.io/docs/hybrid_search_with_milvus.md): Hybrid Search with Milvus
+- [Image Search with Milvus](https://milvus.io/docs/image_similarity_search.md): image search with Milvus
+- [Multimodal RAG](https://milvus.io/docs/multimodal_rag_with_milvus.md): Multimodal RAG with Milvus
+- [Graph RAG with Milvus](https://milvus.io/docs/graph_rag_with_milvus.md): Graph RAG with Milvus
+- [Contextual Retrieval](https://milvus.io/docs/contextual_retrieval_with_milvus.md): Contextal Retrieval is an advanced retrieval method proposed by Anthropic to address the issue of semantic isolation of chunks, which arises in current…
+- [HDBSCAN Clustering](https://milvus.io/docs/hdbscan_clustering_with_milvus.md): In this notebook, we will use the BGE-M3 embedding model to extract embeddings from a news headline dataset, utilize Milvus to efficiently calculate distances…
+- [Vector Visualization](https://milvus.io/docs/vector_visualization.md): In this example, we will show how to visualize the embeddings(vectors) in Milvus using t-SNE.
+- [Movie Recommendation](https://milvus.io/docs/movie_recommendation_with_milvus.md): In this notebook, we will explore how to generate embeddings of movie descriptions using OpenAI and leverage those embeddings within Milvus to recommend movies…
+- [Funnel Search with Matryoshka Embeddings](https://milvus.io/docs/funnel_search_with_matryoshka.md): In this notebook, we examine how to use Matryoshka embeddings with Milvus for semantic search.
+- [Quickstart with Attu](https://milvus.io/docs/quickstart_with_attu.md): Attu is an all-in-one, open-source administration tool for Milvus.
+- [Use AsyncMilvusClient with asyncio](https://milvus.io/docs/use-async-milvus-client-with-asyncio.md): AsyncMilvusClient is an asynchronous MilvusClient that offers a coroutine-based API for non-blocking access to Milvus via asyncio.
+- [Text-to-Image Search with Milvus](https://milvus.io/docs/text_image_search.md): In this tutorial, we will explore how to implement text-based image retrieval using OpenAI’s CLIP (Contrastive Language-Image Pretraining) model and Milvus.
+- [Generating Milvus Query Filter Expressions with Large Language Models](https://milvus.io/docs/generating_milvus_query_filter_expressions.md): In this tutorial, we will demonstrate how to use Large Language Models (LLMs) to automatically generate Milvus filter expressions from natural language queries.
 
-- [Tutorials Overview](https://milvus.io/docs/tutorials-overview.md): Overview of all available tutorials.
-- [Build RAG with Milvus](https://milvus.io/docs/build-rag-with-milvus.md): Build a Retrieval-Augmented Generation pipeline.
-- [Advanced RAG](https://milvus.io/docs/how_to_enhance_your_rag.md): Techniques to enhance RAG pipeline accuracy.
-- [Full-Text Search with Milvus](https://milvus.io/docs/full_text_search_with_milvus.md): Implement BM25-based full-text search.
-- [Hybrid Search with Milvus](https://milvus.io/docs/hybrid_search_with_milvus.md): Combine dense and sparse vectors for hybrid search.
-- [Image Search with Milvus](https://milvus.io/docs/image_similarity_search.md): Build an image similarity search application.
-- [Multimodal RAG](https://milvus.io/docs/multimodal_rag_with_milvus.md): Build a multimodal RAG system using images and text.
-- [Graph RAG with Milvus](https://milvus.io/docs/graph_rag_with_milvus.md): Build a Graph RAG application.
-- [Contextual Retrieval](https://milvus.io/docs/contextual_retrieval_with_milvus.md): Implement contextual retrieval for improved accuracy.
-- [HDBSCAN Clustering](https://milvus.io/docs/hdbscan_clustering_with_milvus.md): Cluster vectors using HDBSCAN.
-- [Vector Visualization](https://milvus.io/docs/vector_visualization.md): Visualize high-dimensional vectors in 2D/3D.
-- [Movie Recommendation](https://milvus.io/docs/movie_recommendation_with_milvus.md): Build a movie recommendation system.
-- [Funnel Search with Matryoshka Embeddings](https://milvus.io/docs/funnel_search_with_matryoshka.md): Implement coarse-to-fine search with Matryoshka embeddings.
-- [Use AsyncMilvusClient with asyncio](https://milvus.io/docs/use-async-milvus-client-with-asyncio.md): Async operations with MilvusClient.
-- [Text-to-Image Search](https://milvus.io/docs/text_image_search.md): Cross-modal search between text and images.
+### Explore More
+
+- [Question Answering System](https://milvus.io/docs/question_answering_system.md): Build a question answering system with Milvus.
+- [Recommender System](https://milvus.io/docs/recommendation_system.md): Build a personalized recommender system with Milvus.
+- [Video Similarity Search](https://milvus.io/docs/video_similarity_search.md): Build a video similarity search system with Milvus.
+- [Audio Similarity Search](https://milvus.io/docs/audio_similarity_search.md): Build an audio similarity search system with Milvus.
+- [DNA Sequence Classification](https://milvus.io/docs/dna_sequence_classification.md): Build a DNA sequence classification system with Milvus.
+- [Text Search Engine](https://milvus.io/docs/text_search_engine.md): Build a text search engine with Milvus.
+- [Image Deduplication System](https://milvus.io/docs/image_deduplication_system.md): Build an image deduplication system with Milvus.
 
 ## FAQs
 
-- [Performance FAQs](https://milvus.io/docs/performance_faq.md): Answers to common performance-related questions.
-- [Product FAQs](https://milvus.io/docs/product_faq.md): Answers to common product-related questions.
-- [Operational FAQs](https://milvus.io/docs/operational_faq.md): Answers to common operational questions.
-- [Milvus Limits](https://milvus.io/docs/limitations.md): System limits and constraints reference.
-- [Troubleshooting](https://milvus.io/docs/troubleshooting.md): Common errors and their solutions.
+- [Performance FAQs](https://milvus.io/docs/performance_faq.md): Find answers to frequently asked questions about search performance, performance enhancements, and other performance related issues.
+- [Product FAQs](https://milvus.io/docs/product_faq.md): Find answers to frequently asked questions about the world's most advanced vector database.
+- [Operational FAQs](https://milvus.io/docs/operational_faq.md): Find answers to commonly asked questions about operations in Milvus.
+- [Milvus Limits](https://milvus.io/docs/limitations.md): Learn about the limits while using Milvus.
+- [Troubleshooting](https://milvus.io/docs/troubleshooting.md): Learn about common issues you may encounter with Milvus and how to overcome them.
 
 ## API Reference
 
-- [PyMilvus (Python)](https://milvus.io/api-reference/pymilvus/v2.6.x/About.md): Complete Python SDK API reference.
-- [Java SDK](https://milvus.io/api-reference/java/v2.6.x/About.md): Complete Java SDK API reference.
-- [Go SDK](https://milvus.io/api-reference/go/v2.6.x/About.md): Complete Go SDK API reference.
-- [Node.js SDK](https://milvus.io/api-reference/node/v2.6.x/About.md): Complete Node.js SDK API reference.
-- [RESTful API](https://milvus.io/api-reference/restful/v2.6.x/About.md): RESTful API reference for language-agnostic access.
+Each SDK is versioned independently of the docs — the newest published version differs per SDK, so do not copy a version segment between them.
 
-## Optional
+- [PyMilvus (Python) — v3.0.x](https://milvus.io/api-reference/pymilvus/v3.0.x/About.md): Python SDK API reference.
+- [Java SDK — v3.0.x](https://milvus.io/api-reference/java/v3.0.x/About.md): Java SDK API reference.
+- [Go SDK — v2.6.x](https://milvus.io/api-reference/go/v2.6.x/About.md): Go SDK API reference.
+- [Node.js SDK — v3.0.x](https://milvus.io/api-reference/node/v3.0.x/About.md): Node.js SDK API reference.
+- [RESTful API — v3.0.x](https://milvus.io/api-reference/restful/v3.0.x/About.md): Language-agnostic HTTP API reference.
+- [C# SDK — v2.2.x](https://milvus.io/api-reference/csharp/v2.2.x/About.md): C# SDK API reference.
+- [C++ SDK — v2.6.x](https://milvus.io/api-reference/cpp/v2.6.x/About.md): C++ SDK API reference.
 
-The following pages provide background context, internal architecture details, and historical information. They can be skipped if context window space is limited.
+## Interactive Learning
 
-- [Milvus Adopters](https://milvus.io/docs/milvus_adopters.md): Major organizations that have adopted Milvus.
-- [Comparison](https://milvus.io/docs/comparison.md): Comparison of Milvus against other vector databases.
-- [Architecture Overview](https://milvus.io/docs/architecture_overview.md): High-level overview of Milvus's distributed system architecture.
-- [Main Components](https://milvus.io/docs/main_components.md): Key components (query nodes, data nodes, index nodes, etc.) and their roles.
-- [Streaming Service](https://milvus.io/docs/streaming_service.md): Streaming service architecture for real-time data ingestion.
-- [Data Processing](https://milvus.io/docs/data_processing.md): How data is processed from ingestion to indexing.
-- [Woodpecker](https://milvus.io/docs/woodpecker_architecture.md): Woodpecker WAL architecture for durable log storage.
-- [Knowhere](https://milvus.io/docs/knowhere.md): Internal module for vector indexing and search algorithms.
-- [Bitset](https://milvus.io/docs/bitset.md): Usage of bitsets for filtering search results.
-- [Timestamp](https://milvus.io/docs/timestamp.md): Timestamp concept for time-travel queries and data consistency.
-- [Time Synchronization](https://milvus.io/docs/time_sync.md): How Milvus synchronizes time across components in a cluster.
-- [Embeddings Overview](https://milvus.io/docs/embeddings.md): Overview of supported embedding models (overlaps with Embeddings & Reranking section).
-- [OpenAI Embeddings](https://milvus.io/docs/embed-with-openai.md): Generate embeddings with OpenAI.
-- [Sentence Transformers](https://milvus.io/docs/embed-with-sentence-transform.md): Generate embeddings with Sentence Transformers.
-- [BGE M3](https://milvus.io/docs/embed-with-bgm-m3.md): Generate dense and sparse embeddings with BGE-M3.
-- [SPLADE](https://milvus.io/docs/embed-with-splade.md): Generate sparse embeddings with SPLADE.
-- [Voyage](https://milvus.io/docs/embed-with-voyage.md): Generate embeddings with Voyage AI.
-- [Jina AI](https://milvus.io/docs/embed-with-jina.md): Generate embeddings with Jina AI.
-- [Cohere](https://milvus.io/docs/embed-with-cohere.md): Generate embeddings with Cohere.
-- [Mistral AI](https://milvus.io/docs/embed-with-mistral-ai.md): Generate embeddings with Mistral AI.
-- [Gemini](https://milvus.io/docs/embed-with-gemini.md): Generate embeddings with Google Gemini.
-- [Rerankers Overview](https://milvus.io/docs/rerankers-overview.md): Overview of supported reranking models.
-- [BGE Reranker](https://milvus.io/docs/rerankers-bge.md): Rerank with BGE reranker model.
-- [Cohere Reranker](https://milvus.io/docs/rerankers-cohere.md): Rerank with Cohere reranker model.
-- [Cross Encoder Reranker](https://milvus.io/docs/rerankers-cross-encoder.md): Rerank with Cross Encoder models.
-- [Voyage Reranker](https://milvus.io/docs/rerankers-voyage.md): Rerank with Voyage AI reranker.
-- [Jina AI Reranker](https://milvus.io/docs/rerankers-jina.md): Rerank with Jina AI reranker.
+Browser-based visualizations of how the index and metric choices actually behave.
+
+- [Learn Milvus](https://milvus.io/learn-milvus): Index of the interactive index and metric visualizations.
+- [IVF Visualized](https://milvus.io/learn-milvus/ivf): FLAT vs IVF search animation with a live nprobe/recall tradeoff.
+- [HNSW Visualized](https://milvus.io/learn-milvus/hnsw): Walk through the HNSW layered graph with tunable M and ef.
+- [DiskANN Visualized](https://milvus.io/learn-milvus/diskann): DiskANN's PQ-in-RAM beam search and SSD re-ranking, animated.
+- [Similarity Metrics Visualized](https://milvus.io/learn-milvus/metric): How L2, cosine, and inner product change which neighbors rank as nearest.
+
+## Sizing Tools
+
+- [Milvus Sizing Tool](https://milvus.io/tools/sizing): Estimate memory, disk, and node counts for a deployment.
+- [Milvus Sizing Tool (Enterprise)](https://milvus.io/tools/sizing-enterprise): Sizing estimates for enterprise deployments.
+- [Milvus Sizing Tool (v2.5.0)](https://milvus.io/tools/sizing-v250): Sizing calculator pinned to the v2.5.0 cost model.
+
+## External Tools
+
+Maintained outside milvus.io; these are the canonical repositories.
+
+- [Attu (Milvus GUI)](https://github.com/zilliztech/attu): Desktop/web GUI for browsing collections and running queries.
+- [Milvus VTS](https://github.com/zilliztech/vts): Vector Transmission Service for migrating data between collections.
+
+## Other Site Sections
+
+These areas hold thousands of pages and are not enumerated here. Do not guess a slug inside them — resolve one through https://milvus.io/sitemap.xml or the section index below.
+
+- [Blog](https://milvus.io/blog): Release announcements, engineering deep dives, and benchmarks. Article URLs are `/blog/<slug>` with no `.md` suffix.
+- [AI Quick Reference](https://milvus.io/ai-quick-reference): Short Q&A pages on vector search and AI topics, at `/ai-quick-reference/<question-slug>`.
+- [Learn AI and Vector DB](https://milvus.io/learn-ai-and-vectordb): Long-form explainers on vector databases and AI infrastructure.
+- [Use Cases](https://milvus.io/use-cases): Production use cases and customer stories.
+- [Milvus Demos](https://milvus.io/milvus-demos): Live demo applications, including reverse image search.
+- [Bootcamp](https://milvus.io/bootcamp): Hands-on notebooks and end-to-end example projects.
+- [Community](https://milvus.io/community): Contributing, governance, and community channels.

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -1,0 +1,571 @@
+/**
+ * Generates public/llms.txt from the docs themselves.
+ *
+ * Why this is generated rather than hand-written: a stale llms.txt is worse
+ * than none. When a page an agent needs is missing from the index, the agent
+ * invents a plausible-looking slug instead — and an unknown doc id is a hard
+ * 404 here (see CreateDocDetailProps.ts, which returns `notFound: true` under
+ * the blocking fallback). Deriving every entry from menuStructure + frontmatter
+ * keeps coverage at 100% and makes fabricated URLs unnecessary.
+ *
+ * Source of truth:
+ *   src/docs/version.json                        -> latest docs version
+ *   src/docs/<ver>/site/en/menuStructure/en.json -> section tree + link labels
+ *   src/docs/<ver>/site/en (markdown frontmatter) -> per-page `summary`
+ *   src/docs/API_Reference and API_Reference_MDX  -> per-SDK reference versions
+ *
+ * Prose that cannot be derived from the docs (the behavioural rules an agent
+ * needs, the URL grammar) lives in the CURATED block below and is the only
+ * part meant to be edited by hand.
+ *
+ * Run: npm run generate:llms
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const DOCS_DIR = path.join(ROOT, 'src/docs');
+const OUT_FILE = path.join(ROOT, 'public/llms.txt');
+const ORIGIN = 'https://milvus.io';
+
+/** Longest a generated description may be before it is trimmed to one sentence. */
+const MAX_SUMMARY = 160;
+
+/** Mirrors DOCS_MINIMUM_VERSION / IGNORE_VERSIONS in src/utils/docs.ts. */
+const DOCS_MINIMUM_VERSION = 'v2.4.x';
+const IGNORE_VERSIONS = ['v2.3.0-beta'];
+const VERSION_REG = /^v\d+\.\d+\.(x|\d+)/;
+
+/** Mirrors LanguageEnum in src/types/localization.ts (minus English). */
+const TRANSLATED_LANGS = [
+  'zh',
+  'zh-hant',
+  'ja',
+  'ko',
+  'de',
+  'fr',
+  'es',
+  'it',
+  'pt',
+  'ru',
+  'ar',
+  'id',
+];
+
+// ---------------------------------------------------------------------------
+// CURATED — hand-maintained prose. Everything else on this page is derived.
+// ---------------------------------------------------------------------------
+
+const CURATED = {
+  /** Blockquote under the H1. */
+  intro:
+    'Milvus is an open-source, high-performance vector database designed for similarity search and AI applications. It supports billion-scale vector storage and search across deployment modes: Milvus Lite (embedded, for prototyping), Milvus Standalone (single-node, for small-scale production), and Milvus Distributed (Kubernetes, for enterprise scale). The primary SDK is PyMilvus for Python; Java, Go, Node.js, and RESTful SDKs are also available.',
+
+  /**
+   * Correctness rules that apply to any generated Milvus code. These exist
+   * because models reliably get these specific things wrong from memory.
+   */
+  codingRules: [
+    'Use the `MilvusClient` interface introduced in v2.4+. Do not use the legacy ORM API (`connections.connect()`, `Collection()`, `utility.list_collections()`) — it is deprecated and will be removed. If you find existing ORM code, advise upgrading the SDK and rewriting against `MilvusClient`.',
+    'Check PyPI (`pip install --upgrade pymilvus`) or npm for the current SDK version rather than relying on a memorized version number.',
+    'To change existing entities use `client.upsert()`. There is no `client.update()`. `upsert()` inserts when the primary key is absent and replaces the whole entity when it is present; use `client.insert()` only for data known not to collide.',
+    "A collection schema is immutable in v2.5.x and earlier — to change it, drop and recreate the collection. From v2.6+ you may add scalar fields with `add_collection_field()`, but vector fields cannot be added and existing fields cannot be modified or removed. Changing a field's data type is not supported in any version. Check the server version before suggesting a schema change.",
+    'Primary keys must be `DataType.INT64` or `DataType.VARCHAR`, must be unique across the whole collection including partitions, and cannot be composite.',
+    'For BM25 full-text search, the BM25 function and its analyzer must be declared when the collection is created; they cannot be added later.',
+    'A vector field must be indexed and the collection loaded before it can be searched.',
+    'In `client.hybrid_search()`, each `AnnSearchRequest` takes exactly one query vector — use one request per vector field — and each search accepts exactly one ranker. Rankers cannot be chained.',
+    'Search iterators (`with-iterators.md`) support basic ANN search only, not hybrid search.',
+    'Both scalar and vector fields support `nullable=True`; only Array of Structs fields (and any field nested inside one) cannot be nullable. A nullable field cannot be a partition key, nullability is fixed at field creation, and a nullable vector field cannot be filtered with `IS NULL` / `IS NOT NULL`. See `nullable-and-default.md`, which is authoritative here.',
+  ],
+
+  /**
+   * Notes attached to a section, keyed by its menu path. Only sections whose
+   * behaviour is easy to get wrong need one.
+   */
+  sectionNotes: {
+    'Get Started':
+      'Start here for first-time setup: run the Quickstart against Milvus Lite, then pick a deployment mode and install an SDK.',
+    'AI Tools':
+      'Written specifically for AI coding agents. `agents_overview.md` is a drop-in AGENTS.md for Milvus; read it before generating Milvus code.',
+    'User Guide > Schema & Data Fields':
+      'Schema changes are heavily constrained — see the schema and primary-key rules above before designing a collection.',
+    'User Guide > Insert & Delete':
+      'Use `upsert()` to modify existing entities; `update()` does not exist.',
+    'User Guide > Indexes':
+      'A vector field must be indexed before the collection can be loaded and searched. AUTOINDEX is the right default for most workloads.',
+    'User Guide > Search':
+      'Load the collection before searching. Hybrid search has per-request constraints — see the rules above.',
+    'Administration Guide':
+      'Deploying, configuring, scaling, monitoring, and securing Milvus in production. Downgrading across versions is not supported.',
+  },
+
+  /**
+   * Site areas that are not part of the docs tree. Every URL here is verified
+   * against public/sitemap-*.xml.
+   */
+  extraSections: [
+    {
+      heading: 'Interactive Learning',
+      note: 'Browser-based visualizations of how the index and metric choices actually behave.',
+      links: [
+        [
+          'Learn Milvus',
+          `${ORIGIN}/learn-milvus`,
+          'Index of the interactive index and metric visualizations.',
+        ],
+        [
+          'IVF Visualized',
+          `${ORIGIN}/learn-milvus/ivf`,
+          'FLAT vs IVF search animation with a live nprobe/recall tradeoff.',
+        ],
+        [
+          'HNSW Visualized',
+          `${ORIGIN}/learn-milvus/hnsw`,
+          'Walk through the HNSW layered graph with tunable M and ef.',
+        ],
+        [
+          'DiskANN Visualized',
+          `${ORIGIN}/learn-milvus/diskann`,
+          "DiskANN's PQ-in-RAM beam search and SSD re-ranking, animated.",
+        ],
+        [
+          'Similarity Metrics Visualized',
+          `${ORIGIN}/learn-milvus/metric`,
+          'How L2, cosine, and inner product change which neighbors rank as nearest.',
+        ],
+      ],
+    },
+    {
+      heading: 'Sizing Tools',
+      links: [
+        [
+          'Milvus Sizing Tool',
+          `${ORIGIN}/tools/sizing`,
+          'Estimate memory, disk, and node counts for a deployment.',
+        ],
+        [
+          'Milvus Sizing Tool (Enterprise)',
+          `${ORIGIN}/tools/sizing-enterprise`,
+          'Sizing estimates for enterprise deployments.',
+        ],
+        [
+          'Milvus Sizing Tool (v2.5.0)',
+          `${ORIGIN}/tools/sizing-v250`,
+          'Sizing calculator pinned to the v2.5.0 cost model.',
+        ],
+      ],
+    },
+    {
+      heading: 'External Tools',
+      note: 'Maintained outside milvus.io; these are the canonical repositories.',
+      links: [
+        [
+          'Attu (Milvus GUI)',
+          'https://github.com/zilliztech/attu',
+          'Desktop/web GUI for browsing collections and running queries.',
+        ],
+        [
+          'Milvus VTS',
+          'https://github.com/zilliztech/vts',
+          'Vector Transmission Service for migrating data between collections.',
+        ],
+      ],
+    },
+    {
+      heading: 'Other Site Sections',
+      note: 'These areas hold thousands of pages and are not enumerated here. Do not guess a slug inside them — resolve one through https://milvus.io/sitemap.xml or the section index below.',
+      links: [
+        [
+          'Blog',
+          `${ORIGIN}/blog`,
+          'Release announcements, engineering deep dives, and benchmarks. Article URLs are `/blog/<slug>` with no `.md` suffix.',
+        ],
+        [
+          'AI Quick Reference',
+          `${ORIGIN}/ai-quick-reference`,
+          'Short Q&A pages on vector search and AI topics, at `/ai-quick-reference/<question-slug>`.',
+        ],
+        [
+          'Learn AI and Vector DB',
+          `${ORIGIN}/learn-ai-and-vectordb`,
+          'Long-form explainers on vector databases and AI infrastructure.',
+        ],
+        [
+          'Use Cases',
+          `${ORIGIN}/use-cases`,
+          'Production use cases and customer stories.',
+        ],
+        [
+          'Milvus Demos',
+          `${ORIGIN}/milvus-demos`,
+          'Live demo applications, including reverse image search.',
+        ],
+        [
+          'Bootcamp',
+          `${ORIGIN}/bootcamp`,
+          'Hands-on notebooks and end-to-end example projects.',
+        ],
+        [
+          'Community',
+          `${ORIGIN}/community`,
+          'Contributing, governance, and community channels.',
+        ],
+      ],
+    },
+  ],
+};
+
+/** Fallback descriptions for the handful of docs with no `summary` frontmatter. */
+const SUMMARY_FALLBACKS = {
+  'glossary.md': 'Glossary of Milvus-specific terms and definitions.',
+  'limit_collection_counts.md':
+    'Configure the maximum number of collections in an instance.',
+  'chunk_cache.md':
+    'Tune the chunk cache that pre-loads data into memory ahead of search.',
+  'scale-dependencies.md':
+    'Scale the etcd, object storage, and message queue dependencies.',
+  'configure_access_logs.md': 'Enable and configure Milvus access logging.',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const readJson = file => JSON.parse(fs.readFileSync(file, 'utf8'));
+
+/** Version strings sort naturally as `v2.10.x` > `v2.9.x` only when padded. */
+const versionKey = v => {
+  const [, major = 0, minor = 0] = v.match(/^v(\d+)\.(\d+)/) || [];
+  return Number(major) * 1e4 + Number(minor);
+};
+
+/** Mirrors generateDocVersionInfo() in src/utils/docs.ts. */
+const resolveDocVersions = () => {
+  const { version: releaseVersion, released } = readJson(
+    path.join(DOCS_DIR, 'version.json')
+  );
+  const minKey = versionKey(DOCS_MINIMUM_VERSION);
+
+  let usable = fs
+    .readdirSync(DOCS_DIR)
+    .filter(name => VERSION_REG.test(name))
+    .filter(name => name <= releaseVersion)
+    .filter(name => !IGNORE_VERSIONS.includes(name))
+    .filter(name => versionKey(name) >= minKey)
+    .sort((a, b) => versionKey(b) - versionKey(a));
+
+  if (released === 'no') usable = usable.filter(v => v !== releaseVersion);
+
+  return { versions: usable, latest: usable[0] };
+};
+
+/** Index every English doc of a version by its filename, which is its page id. */
+const indexDocFiles = siteDir => {
+  const byId = {};
+  const walk = dir => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.md')) byId[entry.name] = full;
+    }
+  };
+  walk(siteDir);
+  return byId;
+};
+
+const unquote = value => {
+  const trimmed = value.trim();
+  const quoted =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"));
+  return quoted ? trimmed.slice(1, -1) : trimmed;
+};
+
+/** Minimum text worth keeping when dropping a trailing sentence fragment. */
+const MIN_KEPT_SENTENCE = 40;
+
+/**
+ * A few docs ship a `summary` that was itself cut mid-sentence upstream (e.g.
+ * milvus-webui.md ends on "You can "). Drop that dangling tail, but only when
+ * a substantial complete sentence remains and the tail is the shorter half —
+ * that keeps "Use mmap, e.g. for large collections" intact, where the period
+ * belongs to an abbreviation rather than a sentence end.
+ */
+const dropTrailingFragment = text => {
+  if (/[.!?:)]$/.test(text)) return text;
+
+  const lastStop = Math.max(
+    text.lastIndexOf('. '),
+    text.lastIndexOf('! '),
+    text.lastIndexOf('? ')
+  );
+  if (lastStop < 0) return text;
+
+  const kept = text.slice(0, lastStop + 1);
+  const tail = text.slice(lastStop + 1).trim();
+  const worthCutting =
+    kept.length >= MIN_KEPT_SENTENCE && tail.length < kept.length;
+  return worthCutting ? kept : text;
+};
+
+/**
+ * Compresses a doc summary to a single line. Prefers the first sentence, so
+ * the description stays informative without carrying the whole abstract.
+ */
+const condense = raw => {
+  const text = dropTrailingFragment(
+    raw
+      // A summary is rendered as the description of a list item, so a markdown
+      // link inside it would nest and break the entry. Keep the label, drop the
+      // target — a few integration docs link out from their summary.
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+  if (!text) return '';
+  if (text.length <= MAX_SUMMARY) return text;
+
+  const firstSentence = text.match(/^.*?[.!?](?=\s|$)/);
+  if (firstSentence && firstSentence[0].length <= MAX_SUMMARY) {
+    return firstSentence[0].trim();
+  }
+
+  const clipped = text.slice(0, MAX_SUMMARY);
+  const lastSpace = clipped.lastIndexOf(' ');
+  return `${clipped.slice(0, lastSpace > 0 ? lastSpace : MAX_SUMMARY)}…`;
+};
+
+const readSummary = (id, filePath) => {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const frontMatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const summary = frontMatter && frontMatter[1].match(/^summary:\s*(.+)$/m);
+  if (summary) {
+    const condensed = condense(unquote(summary[1]));
+    if (condensed) return condensed;
+  }
+  return SUMMARY_FALLBACKS[id] || '';
+};
+
+/** Resolves the newest published version directory for each API reference SDK. */
+const resolveApiReferenceVersions = () => {
+  const roots = ['API_Reference', 'API_Reference_MDX'];
+  const latestBySdk = {};
+
+  for (const root of roots) {
+    const rootDir = path.join(DOCS_DIR, root);
+    if (!fs.existsSync(rootDir)) continue;
+
+    for (const sdk of fs.readdirSync(rootDir)) {
+      const sdkDir = path.join(rootDir, sdk);
+      if (!fs.statSync(sdkDir).isDirectory()) continue;
+
+      const versions = fs
+        .readdirSync(sdkDir)
+        .filter(name => VERSION_REG.test(name))
+        // The MDX tree stores About.mdx, but the route serves it as About.md
+        // either way, so accept both when probing for a published version.
+        .filter(name =>
+          ['About.md', 'About.mdx'].some(entry =>
+            fs.existsSync(path.join(sdkDir, name, entry))
+          )
+        )
+        .sort((a, b) => versionKey(b) - versionKey(a));
+
+      const [newest] = versions;
+      if (!newest) continue;
+      if (
+        !latestBySdk[sdk] ||
+        versionKey(newest) > versionKey(latestBySdk[sdk])
+      ) {
+        latestBySdk[sdk] = newest;
+      }
+    }
+  }
+  return latestBySdk;
+};
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const link = (label, url, description) =>
+  description ? `- [${label}](${url}): ${description}` : `- [${label}](${url})`;
+
+/**
+ * Walks the menu tree, emitting a heading per menu node and a link per leaf.
+ * Heading depth tracks menu depth so the site's own taxonomy survives, which
+ * is what lets an agent find the right page without guessing.
+ */
+const renderMenu = (nodes, docsById, pathLabels, depth, out) => {
+  const leaves = nodes.filter(n => n.id && n.id.endsWith('.md'));
+  const groups = nodes.filter(n => n.children && n.children.length);
+
+  for (const leaf of leaves) {
+    const file = docsById[leaf.id];
+    if (!file) {
+      out.warnings.push(`menu id has no file: ${leaf.id}`);
+      continue;
+    }
+    out.lines.push(
+      link(leaf.label, `${ORIGIN}/docs/${leaf.id}`, readSummary(leaf.id, file))
+    );
+    out.count += 1;
+  }
+  if (leaves.length) out.lines.push('');
+
+  for (const group of groups) {
+    const groupPath = [...pathLabels, group.label];
+    const key = groupPath.join(' > ');
+    // Headings deeper than h6 are not valid Markdown; clamp and keep the label.
+    out.lines.push(`${'#'.repeat(Math.min(depth, 6))} ${group.label}`);
+    out.lines.push('');
+    if (CURATED.sectionNotes[key]) {
+      out.lines.push(CURATED.sectionNotes[key]);
+      out.lines.push('');
+    }
+    renderMenu(group.children, docsById, groupPath, depth + 1, out);
+  }
+};
+
+const renderUrlRules = (versions, latest) => {
+  const pinnable = versions.filter(v => v !== latest);
+  return `## URL rules
+
+Read this before citing any milvus.io URL.
+
+Documentation URLs take exactly one of these four forms:
+
+    ${ORIGIN}/docs/<page-id>                    latest version (${latest}), English
+    ${ORIGIN}/docs/<version>/<page-id>          pinned version
+    ${ORIGIN}/docs/<lang>/<page-id>             translated, latest version
+    ${ORIGIN}/docs/<lang>/<version>/<page-id>   translated, pinned version
+
+- \`<page-id>\` always ends in \`.md\` — for example \`overview.md\`. The suffix is
+  part of the route, not a file extension. \`${ORIGIN}/docs/overview\` is a 404;
+  \`${ORIGIN}/docs/overview.md\` is the page.
+- \`<version>\` is one of: ${pinnable.join(', ')}. Omit the segment entirely for
+  the latest version (${latest}) — there is no \`/docs/${latest}/\` path.
+- \`<lang>\` is one of: ${TRANSLATED_LANGS.join(', ')}. Omit the segment for English.
+- API reference URLs are \`${ORIGIN}/api-reference/<sdk>/<version>/<page>.md\` and
+  are versioned separately from the docs; see the API Reference section.
+- Blog, AI Quick Reference, and Learn pages do not use a \`.md\` suffix.
+
+**Unknown paths return a hard 404 — they do not redirect and they do not fall
+back to a search page.** A URL that looks right but was never published is a
+dead link for the reader.
+
+Therefore: cite only page ids that appear in this file. If the page you need is
+not listed, say it is not in the index rather than assembling a plausible slug
+from the topic name. \`${ORIGIN}/sitemap.xml\` enumerates every published URL and
+is the correct place to resolve anything this file does not cover.`;
+};
+
+const renderApiReference = apiVersions => {
+  const sdks = [
+    ['pymilvus', 'pymilvus', 'PyMilvus (Python)', 'Python SDK API reference.'],
+    ['milvus-sdk-java', 'java', 'Java SDK', 'Java SDK API reference.'],
+    ['milvus-sdk-go', 'go', 'Go SDK', 'Go SDK API reference.'],
+    ['milvus-sdk-node', 'node', 'Node.js SDK', 'Node.js SDK API reference.'],
+    [
+      'milvus-restful',
+      'restful',
+      'RESTful API',
+      'Language-agnostic HTTP API reference.',
+    ],
+    ['milvus-sdk-csharp', 'csharp', 'C# SDK', 'C# SDK API reference.'],
+    ['milvus-sdk-cpp', 'cpp', 'C++ SDK', 'C++ SDK API reference.'],
+  ];
+
+  const lines = ['## API Reference', ''];
+  lines.push(
+    'Each SDK is versioned independently of the docs — the newest published version differs per SDK, so do not copy a version segment between them.',
+    ''
+  );
+
+  for (const [dir, urlSegment, label, description] of sdks) {
+    const version = apiVersions[dir];
+    if (!version) continue;
+    lines.push(
+      link(
+        `${label} — ${version}`,
+        `${ORIGIN}/api-reference/${urlSegment}/${version}/About.md`,
+        description
+      )
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
+};
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const build = () => {
+  const { versions, latest } = resolveDocVersions();
+  if (!latest) throw new Error('no usable docs version found');
+
+  const siteDir = path.join(DOCS_DIR, latest, 'site/en');
+  const menuFile = path.join(siteDir, 'menuStructure/en.json');
+  if (!fs.existsSync(menuFile)) {
+    throw new Error(`missing menu structure: ${menuFile}`);
+  }
+
+  const docsById = indexDocFiles(siteDir);
+  const menu = readJson(menuFile);
+  const apiVersions = resolveApiReferenceVersions();
+
+  const head = [
+    '# Milvus',
+    '',
+    `> ${CURATED.intro}`,
+    '',
+    `This index is generated from the Milvus ${latest} documentation tree. Every URL below resolves to a published page.`,
+    '',
+    renderUrlRules(versions, latest),
+    '',
+    '## Rules for generating Milvus code',
+    '',
+    ...CURATED.codingRules.map(rule => `- ${rule}`),
+    '',
+  ];
+
+  const out = { lines: [], warnings: [], count: 0 };
+  renderMenu(menu, docsById, [], 2, out);
+
+  const extras = CURATED.extraSections.flatMap(section => [
+    `## ${section.heading}`,
+    '',
+    ...(section.note ? [section.note, ''] : []),
+    ...section.links.map(([label, url, description]) =>
+      link(label, url, description)
+    ),
+    '',
+  ]);
+
+  const body = [
+    ...head,
+    ...out.lines,
+    renderApiReference(apiVersions),
+    ...extras,
+  ];
+
+  // Collapse the blank lines that heading/leaf blocks emit independently.
+  const text = `${body
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()}\n`;
+
+  return { text, count: out.count, warnings: out.warnings, latest };
+};
+
+const { text, count, warnings, latest } = build();
+fs.writeFileSync(OUT_FILE, text, 'utf8');
+
+for (const warning of warnings) console.warn(`[llms.txt] ${warning}`);
+console.log(
+  `[llms.txt] ${count} doc links from ${latest} -> public/llms.txt (${(
+    Buffer.byteLength(text) / 1024
+  ).toFixed(1)}KB)`
+);


### PR DESCRIPTION
## Why

`public/llms.txt` was hand-maintained and had drifted. Agents citing milvus.io URLs were fabricating slugs, and a fabricated doc id is a **hard 404** — `CreateDocDetailProps.ts` returns `notFound: true` under the blocking fallback, so there is no redirect or search fallback to soften it.

Root causes found:

| Problem | Detail |
|---|---|
| Coverage | 234 of 458 English docs listed (51%). Missing topics gave agents nothing to cite, so they guessed. |
| Stale versions | Every API reference pinned to `v2.6.x`; pymilvus / java / node / restful have published `v3.0.x`. |
| No URL grammar | Nothing said the `.md` suffix is part of the route, or how version/locale segments work. |
| No anti-fabrication rule | Nothing marked the list as closed or pointed at a fallback. |
| `aiTools/` absent | The 7 prompts written *for coding agents* — including the AGENTS.md for Milvus — were not indexed at all. |

The existing 234 URLs were all valid; the problem was what was missing, not what was wrong.

## What changed

- **`scripts/generate-llms-txt.js`** — derives the index from `menuStructure/en.json` (section tree + labels), doc frontmatter (`summary`), and the API reference version directories on disk. Coverage is now all **395** pages in the site navigation. Version resolution mirrors `generateDocVersionInfo()` in `src/utils/docs.ts`, so it follows `version.json` instead of a hardcoded string.
- **`package.json`** — runs in `build` before `next build`; `npm run generate:llms` for manual runs.
- **`public/llms.txt`** — regenerated. Stays git-tracked (`.gitignore` already un-ignores it), so it is correct even if a deploy skips the build.

Hand-written prose lives in a single `CURATED` block in the script — the intro, the code-generation rules, per-section notes, and the non-docs links. Everything else is derived.

Two additions beyond coverage: a **URL rules** section documenting the four valid URL forms and the 404 behaviour, and an explicit instruction to cite only listed ids and fall back to `sitemap.xml` rather than inventing one.

## One content correction

The old file asserted *"Vector, JSON, and Array fields cannot be nullable"*. That contradicts `userGuide/schema/nullable-and-default.md`, which states nullable is supported for **scalar and vector** fields and excludes only Array of Structs — and documents `IS NULL` limits on nullable vector fields, which only makes sense if they exist. The rule now follows that page.

Note for the docs team: `aiTools/schema_design.md:108` and its table row at `:120` still carry the old claim, and they sit inside the `## Full prompt` block users copy into Cursor / AGENTS.md. That fix belongs in `milvus-io/web-content` (branch `preview`, which is what CI builds against) and is not in this PR.

## Verification

- All **417** milvus.io URLs in the output resolve against `public/sitemap-*.xml` — zero unmatched.
- All 395 doc ids exist on disk; no duplicates; no empty or malformed entries.
- Output is byte-identical across repeated runs.
- Version lookup verified by temporarily setting `version.json` to `v2.6.x` — the generator followed it, then was restored.
- Build chain checked: `Builder.Dockerfile` copies `scripts/`, `src/`, and `public/` before `pnpm build`, and no workflow asserts a clean tree afterwards.

Size grew 33KB → 74KB, which is the cost of full coverage. Trimming descriptions to 100 chars only saves 7KB — the URLs are the bulk — so descriptions were left informative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJSwPaLDR1CnzWyFpTS7Br