### PR TITLE
feat(community): restore Slack entry points and refresh the invite link

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -535,8 +535,8 @@ server {
     rewrite ^ https://discord.gg/8uyFbECzPX? permanent;
   }
 
-  # Redirect /slack to https://join.slack.com/t/milvusio/shared_invite/zt-3nntzngkz-gYwhrdSE4~76k0VMyBfD1Q
+  # Redirect /slack to https://join.slack.com/t/milvusio/shared_invite/zt-4820nj8hv-lsxMOWZuClbRC_vrZ5jZGg
   location = /slack {
-    rewrite ^ https://join.slack.com/t/milvusio/shared_invite/zt-3nntzngkz-gYwhrdSE4~76k0VMyBfD1Q permanent;
+    rewrite ^ https://join.slack.com/t/milvusio/shared_invite/zt-4820nj8hv-lsxMOWZuClbRC_vrZ5jZGg permanent;
   }
 }

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -14,6 +14,7 @@ import {
   GITHUB_VTS_LINK,
   GITHUB_DEEP_SEARCHER_LINK,
   GITHUB_CLAUDE_CONTEXT_LINK,
+  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import { RightTopArrowIcon } from '@/components/icons';
 import { SocialMedias, SocialMediasCN } from '../socialMedias';
@@ -136,12 +137,12 @@ const Footer = (props: Props) => {
           to: MILVUS_OFFICE_HOURS_URL,
           isExternal: true,
         },
-        // {
-        //   id: 'community-2',
-        //   name: t('header:community.slack'),
-        //   to: MILVUS_SLACK_LINK,
-        //   isExternal: true,
-        // },
+        {
+          id: 'community-2',
+          name: t('header:community.slack'),
+          to: MILVUS_SLACK_LINK,
+          isExternal: true,
+        },
         {
           id: 'community-3',
           name: 'Discord',

--- a/src/components/header/navigation.ts
+++ b/src/components/header/navigation.ts
@@ -11,6 +11,7 @@ import {
   GITHUB_MILVUS_CLI_LINK,
   GITHUB_MILVUS_COMMUNITY_LINK,
   GITHUB_VTS_LINK,
+  MILVUS_SLACK_LINK,
   MILVUS_VIDEO_LINK,
 } from '@/consts/links';
 import { MILVUS_OFFICE_HOURS_URL } from '@/consts/externalLinks';
@@ -120,6 +121,12 @@ export const useHeaderNavItems = ({
           {
             label: t('community.officeHours'),
             href: MILVUS_OFFICE_HOURS_URL,
+            rel: 'noopener noreferrer',
+            external: true,
+          },
+          {
+            label: t('community.slack'),
+            href: MILVUS_SLACK_LINK,
             rel: 'noopener noreferrer',
             external: true,
           },

--- a/src/components/socialMedias/index.tsx
+++ b/src/components/socialMedias/index.tsx
@@ -5,6 +5,7 @@ import {
   MILVUS_YOUTUBE_CHANNEL_LINK,
   MILVUS_LINKEDIN_URL,
   MILVUS_BILIBILI_LINK,
+  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import clsx from 'clsx';
 import styles from './index.module.css';
@@ -18,6 +19,7 @@ import {
   MediaWechat,
   MediaBilibili,
   MediaGit,
+  MediaSlack,
 } from '@/components/icons';
 
 const socialJson = [
@@ -27,6 +29,11 @@ const socialJson = [
     link: GITHUB_MILVUS_LINK,
   },
   { icon: <MediaX />, name: 'X', link: MILVUS_TWITTER_LINK },
+  {
+    icon: <MediaSlack />,
+    name: 'Slack',
+    link: MILVUS_SLACK_LINK,
+  },
   {
     icon: <MediaDiscord />,
     name: 'Discord',

--- a/src/consts/links.ts
+++ b/src/consts/links.ts
@@ -4,7 +4,7 @@ export const MEETUP_URL = 'https://www.meetup.com/pro/unstructureddata';
 export const MILVUS_CODELAB_LINK = 'https://codelabs.milvus.io';
 export const MILVUS_VIDEO_LINK =
   'https://www.youtube.com/c/MilvusVectorDatabase';
-export const MILVUS_SLACK_LINK = 'https://milvus.io/slack ';
+export const MILVUS_SLACK_LINK = 'https://milvus.io/slack';
 export const MILVUS_FORUM_LINK = 'https://discuss.milvus.io';
 export const MILVUS_TWITTER_LINK = 'https://twitter.com/milvusio';
 export const MILVUS_YOUTUBE_CHANNEL_LINK =

--- a/src/i18n/ar/header.json
+++ b/src/i18n/ar/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "المزيد من القنوات",
     "officeHours": "ساعات عمل مكتب ميلفوس",
-    "slack": "سلاك"
+    "slack": "Slack"
   },
   "start": "ابدأ",
   "star": "نجمة",

--- a/src/i18n/cn/header.json
+++ b/src/i18n/cn/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "更多社区",
     "officeHours": "米尔沃斯办公时间",
-    "slack": "松弛"
+    "slack": "Slack"
   },
   "start": "开始使用",
   "star": "Star",

--- a/src/i18n/id/header.json
+++ b/src/i18n/id/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "Lebih Banyak Channel",
     "officeHours": "Jam Kantor Milvus",
-    "slack": "Kendur"
+    "slack": "Slack"
   },
   "start": "Mulai",
   "star": "Bintang",

--- a/src/i18n/ja/header.json
+++ b/src/i18n/ja/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "その他のチャンネル",
     "officeHours": "ミルバス営業時間",
-    "slack": "スラック"
+    "slack": "Slack"
   },
   "start": "始める",
   "star": "スター",

--- a/src/i18n/zh-hant/header.json
+++ b/src/i18n/zh-hant/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "更多頻道",
     "officeHours": "Milvus 辦公時間",
-    "slack": "懶惰"
+    "slack": "Slack"
   },
   "start": "開始使用",
   "star": "星標",

--- a/src/parts/community/Community.tsx
+++ b/src/parts/community/Community.tsx
@@ -2,7 +2,11 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Layout from '@/components/layout/commonLayout';
 import { useTranslation } from 'react-i18next';
-import { DISCORD_INVITE_URL, MILVUS_BILIBILI_LINK } from '@/consts';
+import {
+  DISCORD_INVITE_URL,
+  MILVUS_BILIBILI_LINK,
+  MILVUS_SLACK_LINK,
+} from '@/consts';
 import classes from '@/styles/community.module.css';
 import pageClasses from '@/styles/responsive.module.css';
 import clsx from 'clsx';
@@ -43,13 +47,13 @@ export const Community: FC<Props> = (props: Props) => {
       catLabel: t('join'),
       show: true,
     },
-    // {
-    //   label: 'Slack',
-    //   imgUrl: '/images/community/socialMedia/slack.svg',
-    //   href: MILVUS_SLACK_LINK,
-    //   catLabel: t('join'),
-    //   show: true,
-    // },
+    {
+      label: 'Slack',
+      imgUrl: '/images/community/socialMedia/slack.svg',
+      href: MILVUS_SLACK_LINK,
+      catLabel: t('join'),
+      show: true,
+    },
     {
       label: 'Discord',
       imgUrl: '/images/community/socialMedia/discord.svg',
@@ -103,13 +107,13 @@ export const Community: FC<Props> = (props: Props) => {
       catLabel: t('join'),
       show: isCnSite,
     },
-    {
-      label: 'Ambassador',
-      imgUrl: '/images/community/socialMedia/milvus-ambassador.svg',
-      href: 'https://docs.google.com/forms/d/e/1FAIpQLSfkVTYObayOaND8M1ci9eF_YWvoKDb-xQjLJYZ-LhbCdLAt2Q/viewform',
-      catLabel: t('apply'),
-      show: !isCnSite,
-    },
+    // {
+    //   label: 'Ambassador',
+    //   imgUrl: '/images/community/socialMedia/milvus-ambassador.svg',
+    //   href: 'https://docs.google.com/forms/d/e/1FAIpQLSfkVTYObayOaND8M1ci9eF_YWvoKDb-xQjLJYZ-LhbCdLAt2Q/viewform',
+    //   catLabel: t('apply'),
+    //   show: !isCnSite,
+    // },
     {
       label: 'Milvus 北辰大使',
       imgUrl: '/images/community/socialMedia/milvus-ambassador.svg',


### PR DESCRIPTION
## What

`milvus.io/slack` was redirecting to an expired workspace invite (`zt-3nntzngkz-…`), and every Slack entry point on the site had been commented out. This points the redirect at the current invite and brings the links back.

## Changes

| Area | Change |
| --- | --- |
| `conf/conf.d/client.conf` | `/slack` now 301s to `https://join.slack.com/t/milvusio/shared_invite/zt-4820nj8hv-lsxMOWZuClbRC_vrZ5jZGg` |
| `src/components/header/navigation.ts` | Slack added to the Community dropdown, between **Milvus Office Hours** and **Discord** |
| `src/components/footer/index.tsx` | Same position in the footer's Community column (uncommented the existing `community-2` item, id unchanged) |
| `src/parts/community/Community.tsx` | Slack card re-enabled on `/community` |
| `src/components/socialMedias/index.tsx` | Slack icon added to the social media row |
| `src/consts/links.ts` | Dropped a trailing space in `MILVUS_SLACK_LINK` — it was emitting `"https://milvus.io/slack "` as the href |
| `src/i18n/{ar,cn,id,ja,zh-hant}/header.json` | `community.slack` had been machine-translated into a common word (`松弛`, `懶惰`, `Kendur`, `スラック`, `سلاك`). Restored the brand name, matching how Discord and GitHub are handled in the same menu |

All link entries reuse `MILVUS_SLACK_LINK` (`https://milvus.io/slack`) rather than hardcoding the invite URL, so future invite rotations only touch the nginx conf.

## Note for reviewers

This also **comments out the Ambassador card** on `/community` (`Community.tsx`). That's unrelated to Slack — carried along from the working tree. Say the word and I'll split it out.

## Verification

- `npx tsc --noEmit` passes
- `community.slack` key confirmed present in all 13 locales
- `MediaSlack` icon and `public/images/community/socialMedia/slack.svg` both exist

The `/slack` redirect lives in the nginx conf, which only takes effect in the deployed container — it can't be exercised via `pnpm dev`, so it needs a check on the preview environment after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rVG9SiDnND82bcdtPfokB