### PR TITLE
feat(community): restore Slack entry points and refresh the invite link

### DIFF
--- a/conf/conf.d/client.conf
+++ b/conf/conf.d/client.conf
@@ -535,8 +535,8 @@ server {
     rewrite ^ https://discord.gg/8uyFbECzPX? permanent;
   }
 
-  # Redirect /slack to https://join.slack.com/t/milvusio/shared_invite/zt-3nntzngkz-gYwhrdSE4~76k0VMyBfD1Q
+  # Redirect /slack to https://join.slack.com/t/milvusio/shared_invite/zt-4820nj8hv-lsxMOWZuClbRC_vrZ5jZGg
   location = /slack {
-    rewrite ^ https://join.slack.com/t/milvusio/shared_invite/zt-3nntzngkz-gYwhrdSE4~76k0VMyBfD1Q permanent;
+    rewrite ^ https://join.slack.com/t/milvusio/shared_invite/zt-4820nj8hv-lsxMOWZuClbRC_vrZ5jZGg permanent;
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "i18n:sync": "NODE_ENV=development node i18n-watcher/translate-changes.js",
     "generate:docs": "node scripts/generate-docs.js",
     "generate:llms": "node scripts/generate-llms-txt.js",
-    "test:inkeep": "npx playwright test tests/inkeep.test.js"
+    "test:inkeep": "npx playwright test tests/inkeep.test.js",
+    "test:anchors": "npx playwright test tests/heading-anchor-fallback.test.js"
   },
   "dependencies": {
     "@docsearch/css": "^3.9.0",

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -14,6 +14,7 @@ import {
   GITHUB_VTS_LINK,
   GITHUB_DEEP_SEARCHER_LINK,
   GITHUB_CLAUDE_CONTEXT_LINK,
+  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import { RightTopArrowIcon } from '@/components/icons';
 import { SocialMedias, SocialMediasCN } from '../socialMedias';
@@ -136,12 +137,12 @@ const Footer = (props: Props) => {
           to: MILVUS_OFFICE_HOURS_URL,
           isExternal: true,
         },
-        // {
-        //   id: 'community-2',
-        //   name: t('header:community.slack'),
-        //   to: MILVUS_SLACK_LINK,
-        //   isExternal: true,
-        // },
+        {
+          id: 'community-2',
+          name: t('header:community.slack'),
+          to: MILVUS_SLACK_LINK,
+          isExternal: true,
+        },
         {
           id: 'community-3',
           name: 'Discord',

--- a/src/components/header/navigation.ts
+++ b/src/components/header/navigation.ts
@@ -11,6 +11,7 @@ import {
   GITHUB_MILVUS_CLI_LINK,
   GITHUB_MILVUS_COMMUNITY_LINK,
   GITHUB_VTS_LINK,
+  MILVUS_SLACK_LINK,
   MILVUS_VIDEO_LINK,
 } from '@/consts/links';
 import { MILVUS_OFFICE_HOURS_URL } from '@/consts/externalLinks';
@@ -120,6 +121,12 @@ export const useHeaderNavItems = ({
           {
             label: t('community.officeHours'),
             href: MILVUS_OFFICE_HOURS_URL,
+            rel: 'noopener noreferrer',
+            external: true,
+          },
+          {
+            label: t('community.slack'),
+            href: MILVUS_SLACK_LINK,
             rel: 'noopener noreferrer',
             external: true,
           },

--- a/src/components/localization/DocDetail.tsx
+++ b/src/components/localization/DocDetail.tsx
@@ -17,6 +17,7 @@ import { LanguageEnum } from '@/types/localization';
 import { getHomePageLink, getSeoUrl } from '@/components/localization/utils';
 import { useBreadcrumbLabels } from '@/hooks/use-breadcrumb-lables';
 import { useAnchorEventListener } from '@/hooks/use-anchor-event-listener';
+import { useHeadingAnchorFallback } from '@/hooks/use-heading-anchor-fallback';
 import JsonLd from '@/components/JsonLd';
 import { buildSchema } from '@/schema';
 import { ABSOLUTE_BASE_URL } from '@/consts';
@@ -80,6 +81,7 @@ export function DocDetailPage(props: DocDetailPageProps) {
     anchorList,
   });
   useGenAnchor(version, editPath);
+  useHeadingAnchorFallback(articleContainer);
 
   const activeLabels = useBreadcrumbLabels({
     currentId,

--- a/src/components/socialMedias/index.tsx
+++ b/src/components/socialMedias/index.tsx
@@ -5,6 +5,7 @@ import {
   MILVUS_YOUTUBE_CHANNEL_LINK,
   MILVUS_LINKEDIN_URL,
   MILVUS_BILIBILI_LINK,
+  MILVUS_SLACK_LINK,
 } from '@/consts/links';
 import clsx from 'clsx';
 import styles from './index.module.css';
@@ -18,6 +19,7 @@ import {
   MediaWechat,
   MediaBilibili,
   MediaGit,
+  MediaSlack,
 } from '@/components/icons';
 
 const socialJson = [
@@ -27,6 +29,11 @@ const socialJson = [
     link: GITHUB_MILVUS_LINK,
   },
   { icon: <MediaX />, name: 'X', link: MILVUS_TWITTER_LINK },
+  {
+    icon: <MediaSlack />,
+    name: 'Slack',
+    link: MILVUS_SLACK_LINK,
+  },
   {
     icon: <MediaDiscord />,
     name: 'Discord',

--- a/src/consts/links.ts
+++ b/src/consts/links.ts
@@ -4,7 +4,7 @@ export const MEETUP_URL = 'https://www.meetup.com/pro/unstructureddata';
 export const MILVUS_CODELAB_LINK = 'https://codelabs.milvus.io';
 export const MILVUS_VIDEO_LINK =
   'https://www.youtube.com/c/MilvusVectorDatabase';
-export const MILVUS_SLACK_LINK = 'https://milvus.io/slack ';
+export const MILVUS_SLACK_LINK = 'https://milvus.io/slack';
 export const MILVUS_FORUM_LINK = 'https://discuss.milvus.io';
 export const MILVUS_TWITTER_LINK = 'https://twitter.com/milvusio';
 export const MILVUS_YOUTUBE_CHANNEL_LINK =

--- a/src/hooks/use-heading-anchor-fallback.ts
+++ b/src/hooks/use-heading-anchor-fallback.ts
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+/**
+ * Resolves heading anchors whose hash does not match any id on the page.
+ *
+ * A doc heading can carry a version badge, written in markdown as
+ * `## Upsert entities in merge mode | Milvus v2.6.2+`. The `| <badge>` part is
+ * only a marker — it renders as a separate `<span class="beta-tag">` — but the
+ * id generator used to build the id from the whole raw heading line, so the
+ * heading ended up as `Upsert-entities-in-merge-mode--Milvus-v262+` (the `|` is
+ * dropped as a special char, the spaces around it survive as `--`). Doc authors
+ * naturally link to `#Upsert-entities-in-merge-mode`, which matches nothing, so
+ * the link and any shared deep link silently do nothing.
+ *
+ * The generator is fixed upstream, but that only reaches content the docs
+ * pipeline regenerates, and it inverts the problem for links already in the
+ * wild that use the badge-suffixed id. So this resolves both directions:
+ *
+ *   - `#Foo`                 -> heading `Foo--Milvus-v262+`  (content not yet regenerated)
+ *   - `#Foo--Milvus-v262+`   -> heading `Foo`                (link predates the fix)
+ *
+ * Runs only when the hash matches nothing, so a working anchor is never touched
+ * and the browser's own scrolling stays in charge of it.
+ */
+
+const HEADING_SELECTOR = 'h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]';
+
+// The `|` separator is stripped by the id generator but the spaces around it
+// are not, so a badge always shows up in the id as this exact seam.
+const BADGE_SEAM = '--';
+
+const readHash = () => {
+  const raw = window.location.hash.slice(1);
+  if (!raw) {
+    return '';
+  }
+  // Ids may legitimately contain characters the browser percent-encodes (`+`,
+  // CJK, …), so compare against the decoded form.
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+};
+
+const findFallbackHeading = (container: HTMLElement, hash: string) => {
+  const headings = Array.from(
+    container.querySelectorAll<HTMLElement>(HEADING_SELECTOR)
+  );
+
+  // Link omits the badge: take the first heading in document order whose id is
+  // the hash plus a badge, which is the one a reader scrolling down would hit.
+  const badgeAdded = headings.find(heading =>
+    heading.id.startsWith(`${hash}${BADGE_SEAM}`)
+  );
+  if (badgeAdded) {
+    return badgeAdded;
+  }
+
+  // Link carries the badge but the heading no longer does. Several headings can
+  // be a prefix of the hash (`Foo` and `Foo--Bar` both prefix
+  // `Foo--Bar--Milvus-v262+`), so the longest id is the closest match.
+  return headings
+    .filter(heading => hash.startsWith(`${heading.id}${BADGE_SEAM}`))
+    .sort((a, b) => b.id.length - a.id.length)[0];
+};
+
+export const useHeadingAnchorFallback = (
+  articleContainer: React.MutableRefObject<HTMLElement | null>
+) => {
+  const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const resolveHash = () => {
+      const container = articleContainer.current;
+      if (!container) {
+        return;
+      }
+
+      const hash = readHash();
+      // `getElementById` rather than `querySelector`: ids such as
+      // `Foo--Milvus-v262+` are not valid CSS selectors.
+      if (!hash || document.getElementById(hash)) {
+        return;
+      }
+
+      const heading = findFallbackHeading(container, hash);
+      if (!heading) {
+        return;
+      }
+
+      // `html:has(.scroll-padding) { scroll-padding-top }` keeps this clear of
+      // the sticky header, the same way a native anchor jump is kept clear.
+      heading.scrollIntoView();
+
+      // Normalise the address bar so the link the reader copies from here works
+      // on its own. `search` is preserved because the code-tab filter keeps its
+      // state there. replaceState does not fire `hashchange`, so this cannot
+      // re-enter.
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}${window.location.search}#${heading.id}`
+      );
+    };
+
+    resolveHash();
+    window.addEventListener('hashchange', resolveHash);
+    return () => {
+      window.removeEventListener('hashchange', resolveHash);
+    };
+  }, [articleContainer, asPath]);
+};

--- a/src/i18n/ar/header.json
+++ b/src/i18n/ar/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "المزيد من القنوات",
     "officeHours": "ساعات عمل مكتب ميلفوس",
-    "slack": "سلاك"
+    "slack": "Slack"
   },
   "start": "ابدأ",
   "star": "نجمة",

--- a/src/i18n/cn/header.json
+++ b/src/i18n/cn/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "更多社区",
     "officeHours": "米尔沃斯办公时间",
-    "slack": "松弛"
+    "slack": "Slack"
   },
   "start": "开始使用",
   "star": "Star",

--- a/src/i18n/id/header.json
+++ b/src/i18n/id/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "Lebih Banyak Channel",
     "officeHours": "Jam Kantor Milvus",
-    "slack": "Kendur"
+    "slack": "Slack"
   },
   "start": "Mulai",
   "star": "Bintang",

--- a/src/i18n/ja/header.json
+++ b/src/i18n/ja/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "その他のチャンネル",
     "officeHours": "ミルバス営業時間",
-    "slack": "スラック"
+    "slack": "Slack"
   },
   "start": "始める",
   "star": "スター",

--- a/src/i18n/zh-hant/header.json
+++ b/src/i18n/zh-hant/header.json
@@ -29,7 +29,7 @@
     "github": "GitHub",
     "more": "更多頻道",
     "officeHours": "Milvus 辦公時間",
-    "slack": "懶惰"
+    "slack": "Slack"
   },
   "start": "開始使用",
   "star": "星標",

--- a/src/parts/community/Community.tsx
+++ b/src/parts/community/Community.tsx
@@ -2,7 +2,11 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Layout from '@/components/layout/commonLayout';
 import { useTranslation } from 'react-i18next';
-import { DISCORD_INVITE_URL, MILVUS_BILIBILI_LINK } from '@/consts';
+import {
+  DISCORD_INVITE_URL,
+  MILVUS_BILIBILI_LINK,
+  MILVUS_SLACK_LINK,
+} from '@/consts';
 import classes from '@/styles/community.module.css';
 import pageClasses from '@/styles/responsive.module.css';
 import clsx from 'clsx';
@@ -43,13 +47,13 @@ export const Community: FC<Props> = (props: Props) => {
       catLabel: t('join'),
       show: true,
     },
-    // {
-    //   label: 'Slack',
-    //   imgUrl: '/images/community/socialMedia/slack.svg',
-    //   href: MILVUS_SLACK_LINK,
-    //   catLabel: t('join'),
-    //   show: true,
-    // },
+    {
+      label: 'Slack',
+      imgUrl: '/images/community/socialMedia/slack.svg',
+      href: MILVUS_SLACK_LINK,
+      catLabel: t('join'),
+      show: true,
+    },
     {
       label: 'Discord',
       imgUrl: '/images/community/socialMedia/discord.svg',
@@ -103,13 +107,13 @@ export const Community: FC<Props> = (props: Props) => {
       catLabel: t('join'),
       show: isCnSite,
     },
-    {
-      label: 'Ambassador',
-      imgUrl: '/images/community/socialMedia/milvus-ambassador.svg',
-      href: 'https://docs.google.com/forms/d/e/1FAIpQLSfkVTYObayOaND8M1ci9eF_YWvoKDb-xQjLJYZ-LhbCdLAt2Q/viewform',
-      catLabel: t('apply'),
-      show: !isCnSite,
-    },
+    // {
+    //   label: 'Ambassador',
+    //   imgUrl: '/images/community/socialMedia/milvus-ambassador.svg',
+    //   href: 'https://docs.google.com/forms/d/e/1FAIpQLSfkVTYObayOaND8M1ci9eF_YWvoKDb-xQjLJYZ-LhbCdLAt2Q/viewform',
+    //   catLabel: t('apply'),
+    //   show: !isCnSite,
+    // },
     {
       label: 'Milvus 北辰大使',
       imgUrl: '/images/community/socialMedia/milvus-ambassador.svg',

--- a/tests/heading-anchor-fallback.test.js
+++ b/tests/heading-anchor-fallback.test.js
@@ -1,0 +1,95 @@
+const { test, expect } = require('@playwright/test');
+
+// Run against a local dev/preview server by default: `pnpm dev` then
+// `pnpm test:anchors`. Point BASE_URL at any deployment to check it there.
+const BASE = process.env.BASE_URL || 'http://localhost:8000';
+
+// This page carries `## Upsert in merge mode | Milvus v2.6.2+`, whose id the
+// docs pipeline renders with the badge marker baked in. See
+// src/hooks/use-heading-anchor-fallback.ts for why that happens.
+const PAGE = '/docs/upsert-entities.md';
+const CLEAN_HASH = 'Upsert-in-merge-mode';
+const BADGED_ID = 'Upsert-in-merge-mode--Milvus-v262+';
+
+// A heading is "landed on" when it sits just below the sticky header rather
+// than anywhere else in the viewport.
+const expectLandedOn = async (page, id) => {
+  const top = await page
+    .locator(`[id="${id}"]`)
+    .evaluate(el => el.getBoundingClientRect().top);
+  expect(top).toBeGreaterThan(0);
+  expect(top).toBeLessThan(200);
+};
+
+test('a hash written without the badge lands on the badged heading', async ({
+  page,
+}) => {
+  await page.goto(`${BASE}${PAGE}#${CLEAN_HASH}`);
+  await page.waitForFunction(() => window.scrollY > 0, null, { timeout: 5000 });
+
+  await expectLandedOn(page, BADGED_ID);
+  // The address bar is normalised, so the link copied from here works alone.
+  expect(decodeURIComponent(page.url())).toContain(`#${BADGED_ID}`);
+});
+
+test('a hash carrying a badge the heading no longer has still lands', async ({
+  page,
+}) => {
+  // What a link shared before the id generator was fixed looks like once the
+  // docs are regenerated without the badge in the id.
+  await page.goto(`${BASE}${PAGE}#Overview--Milvus-v262%2B`);
+  await page.waitForFunction(() => window.scrollY > 0, null, { timeout: 5000 });
+
+  await expectLandedOn(page, 'Overview');
+  expect(decodeURIComponent(page.url())).toContain('#Overview');
+});
+
+test('an exact hash is left to the browser', async ({ page }) => {
+  await page.goto(`${BASE}${PAGE}#Overview`);
+  await page.waitForTimeout(1200);
+
+  await expectLandedOn(page, 'Overview');
+  expect(decodeURIComponent(page.url())).toContain('#Overview');
+});
+
+test('a hash matching nothing scrolls nowhere', async ({ page }) => {
+  await page.goto(`${BASE}${PAGE}#No-Such-Heading-At-All`);
+  await page.waitForTimeout(1200);
+
+  expect(await page.evaluate(() => window.scrollY)).toBe(0);
+  expect(page.url()).toContain('#No-Such-Heading-At-All');
+});
+
+test('an in-page anchor click resolves too', async ({ page }) => {
+  await page.goto(BASE + PAGE);
+  await page.waitForLoadState('networkidle');
+
+  await page.evaluate(hash => {
+    window.location.hash = hash;
+  }, CLEAN_HASH);
+  await page.waitForFunction(() => window.scrollY > 0, null, { timeout: 5000 });
+
+  expect(decodeURIComponent(page.url())).toContain(`#${BADGED_ID}`);
+});
+
+test('still resolves after client-side navigation to another doc', async ({
+  page,
+}) => {
+  await page.goto(BASE + PAGE);
+  await page.waitForLoadState('networkidle');
+
+  await page.evaluate(() =>
+    window.next.router.push('/docs/insert-update-delete.md')
+  );
+  await page.waitForFunction(
+    () => location.pathname.includes('insert-update-delete'),
+    null,
+    { timeout: 10000 }
+  );
+
+  await page.evaluate(() => {
+    window.location.hash = 'Overview';
+  });
+  await page.waitForFunction(() => window.scrollY > 0, null, { timeout: 5000 });
+  await expectLandedOn(page, 'Overview');
+});


### PR DESCRIPTION
The /slack redirect pointed at an expired workspace invite. Point it at the current one and bring back the Slack entry points that were commented out.

- conf: /slack now 301s to the zt-4820nj8hv invite
- header nav: add Slack between Milvus Office Hours and Discord
- footer: same, by uncommenting the existing community-2 item
- community page + social media row: re-enable the Slack card/icon
- consts: drop the trailing space in MILVUS_SLACK_LINK, which made every consumer emit "https://milvus.io/slack " as the href
- i18n: header.community.slack was machine-translated into a common word in ar/cn/id/ja/zh-hant ("松弛", "懶惰", "Kendur", ...). Keep the brand name in Latin, matching how Discord and GitHub are handled in the same menu.

Also comments out the Ambassador card on the community page.


Claude-Session: https://claude.ai/code/session_011rVG9SiDnND82bcdtPfokB