### PR TITLE
feat(analytics): add X conversion tracking base code

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -69,6 +69,18 @@ function MyApp({ Component, pageProps }) {
               id="google-tag-manager"
             />
           )}
+          {ENABLE_ANALYTICS && (
+            <Script
+              strategy="lazyOnload"
+              dangerouslySetInnerHTML={{
+                __html: `!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+twq('config','pt39h');`,
+              }}
+              id="x-conversion-tracking"
+            />
+          )}
           <InkeepChatButtonContainer />
           <LazyCookieConsent />
         </>


### PR DESCRIPTION
## Summary

- Add the X (Twitter) conversion tracking base code (pixel id `pt39h`) to `src/pages/_app.tsx`.
- Wired the same way as GTM: `next/script` with `strategy="lazyOnload"`, gated by `ENABLE_ANALYTICS` so it only loads in production builds.

## Notes

- The base code reports one PageView on initial load. SPA route changes do not re-fire it; add `twq('event', ...)` calls later if per-page or conversion events are needed.
- The cookie consent banner does not gate third-party scripts, so this loads under the same conditions as GTM.

## Test plan

- [x] `tsc --noEmit` and Prettier pass
- [ ] Verify on preview deploy that `https://static.ads-twitter.com/uwt.js` loads and `window.twq` is defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ktcKPrKch6PGkqGpGs5Yd
