### PR TITLE
feat(analytics): add X conversion tracking base code

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -69,6 +69,18 @@ function MyApp({ Component, pageProps }) {
               id="google-tag-manager"
             />
           )}
+          {ENABLE_ANALYTICS && (
+            <Script
+              strategy="lazyOnload"
+              dangerouslySetInnerHTML={{
+                __html: `!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+twq('config','pt39h');`,
+              }}
+              id="x-conversion-tracking"
+            />
+          )}
           <InkeepChatButtonContainer />
           <LazyCookieConsent />
         </>


### PR DESCRIPTION
Load the X (Twitter) pixel (id pt39h) alongside GTM in _app.tsx. It uses the same lazyOnload strategy and is gated by ENABLE_ANALYTICS, so it only runs in production builds.


Claude-Session: https://claude.ai/code/session_013ktcKPrKch6PGkqGpGs5Yd