### PR TITLE
feat(analytics): add Reddit Pixel base code

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -81,6 +81,15 @@ twq('config','pt39h');`,
               id="x-conversion-tracking"
             />
           )}
+          {ENABLE_ANALYTICS && (
+            <Script
+              strategy="lazyOnload"
+              dangerouslySetInnerHTML={{
+                __html: `!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js?pixel_id=a2_jneinvigvgpa",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','a2_jneinvigvgpa');rdt('track', 'PageVisit');`,
+              }}
+              id="reddit-pixel"
+            />
+          )}
           <InkeepChatButtonContainer />
           <LazyCookieConsent />
         </>


### PR DESCRIPTION
## Summary

- Add the Reddit Pixel (id `a2_jneinvigvgpa`) to `src/pages/_app.tsx`, next to the GTM and X tracking scripts.
- Same `lazyOnload` strategy and `ENABLE_ANALYTICS` gate as the X pixel, so it only loads in production builds.

## Notes

- `PageVisit` fires once on initial page load, matching the current X pixel behaviour. Client-side route changes are not tracked yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcEcTerFe2Ghdxcy1gorv5